### PR TITLE
Adding K8s Events for iam-manager operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 vendor/
 mocks/
+gomock*/
 
 #IDE files
 .idea/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  range: "50...90"
+  status:
+    project:
+      default:
+        target: auto
+        treshold: 5%
+        base: auto
+
+ignore:
+  - "**/zz_generated.*"
+  - "bin"
+  - "config"
+  - "hack"
+  - "docs"
+  - "**/mocks/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,7 @@
 coverage:
   range: "50...90"
   status:
-    project:
-      default:
-        target: auto
-        treshold: 5%
-        base: auto
+    patch: off
 
 ignore:
   - "**/zz_generated.*"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,15 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - iammanager.keikoproj.io
   resources:
   - iamroles

--- a/controllers/iamrole_controller.go
+++ b/controllers/iamrole_controller.go
@@ -238,32 +238,6 @@ func (r *IamroleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *IamroleReconciler) HandleEvents(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, eType string, reason string, message string, count int) {
-
-	sEvent := &v1.Event{
-		Type:    eType,
-		Reason:  reason,
-		Message: message,
-		Source:  v1.EventSource{Component: "iam-manager"},
-		InvolvedObject: v1.ObjectReference{
-			Kind:            iamRole.Kind,
-			Namespace:       iamRole.ObjectMeta.Namespace,
-			Name:            iamRole.GenerateName,
-			ResourceVersion: iamRole.ResourceVersion,
-			APIVersion:      iamRole.APIVersion,
-		},
-	}
-	//This is first time. lets add all the timestamps
-	if count == 0 {
-		sEvent.FirstTimestamp = iamRole.CreationTimestamp
-		sEvent.LastTimestamp = iamRole.CreationTimestamp
-	}
-
-	sEvent.Name = fmt.Sprintf("event-success-%s", iamRole.ObjectMeta.Namespace)
-
-	r.K8sClient.AddEvents(ctx, iamRole.ObjectMeta.Namespace, sEvent)
-}
-
 //UpdateStatus function updates the status based on the process step
 func (r *IamroleReconciler) UpdateStatus(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, status iammanagerv1alpha1.IamroleStatus, state iammanagerv1alpha1.State) {
 	log := log.Logger(ctx, "controllers", "iamrole_controller", "UpdateStatus")

--- a/controllers/iamrole_controller.go
+++ b/controllers/iamrole_controller.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
-	"github.com/keikoproj/iam-manager/pkg/k8s"
 	"github.com/keikoproj/iam-manager/pkg/log"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
@@ -46,7 +45,6 @@ const (
 type IamroleReconciler struct {
 	client.Client
 	IAMClient *awsapi.IAM
-	K8sClient *k8s.Client
 	Recorder  record.EventRecorder
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
+	golang.org/x/tools v0.0.0-20200207224406-61798d64f025 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/klog v0.3.0
 	sigs.k8s.io/controller-runtime v0.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -110,6 +111,9 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2I
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20200207224406-61798d64f025 h1:i84/3szN87uN9jFX/jRqUbszQto2oAsFlqPf6lbR8H4=
+golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8 h1:q1Qvjzs/iEd
 k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d h1:Jmdtdt1ZnoGfWWIIik61Z7nKYgO3J+swQJtPYsP9wHA=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible h1:U5Bt+dab9K8qaUmXINrkXO135kA11/i5Kg1RUydgaMQ=
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.3.0 h1:0VPpR+sizsiivjIfIAQH/rl8tan6jvWkS7lU+0di3lE=

--- a/hack/iam-manager.yaml
+++ b/hack/iam-manager.yaml
@@ -588,6 +588,15 @@ metadata:
   name: iam-manager-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - iammanager.keikoproj.io
   resources:
   - iamroles

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
+	"github.com/keikoproj/iam-manager/pkg/k8s"
 	"github.com/keikoproj/iam-manager/pkg/log"
 	"os"
 
@@ -68,9 +69,11 @@ func main() {
 	}
 
 	log.V(1).Info("Setting up reconciler with manager")
+
 	if err = (&controllers.IamroleReconciler{
 		Client:    mgr.GetClient(),
 		IAMClient: awsapi.New(),
+		Recorder:  k8s.NewK8sClientDoOrDie().SetUpEventHandler(context.Background()),
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "Iamrole")
 		os.Exit(1)

--- a/pkg/awsapi/iam.go
+++ b/pkg/awsapi/iam.go
@@ -432,7 +432,7 @@ func (i *IAM) DeleteRole(ctx context.Context, roleName string) error {
 
 	// Detach managed policies
 	for _, policy := range managedPolicyList.AttachedPolicies {
-		if err := i.DetachRolePolicy(ctx, aws.StringValue(policy.PolicyName), roleName); err != nil {
+		if err := i.DetachRolePolicy(ctx, aws.StringValue(policy.PolicyArn), roleName); err != nil {
 			log.Error(err, "Unable to delete the policy", "policyName", aws.StringValue(policy.PolicyName))
 			return err
 		}
@@ -521,15 +521,13 @@ func (i *IAM) DeleteInlinePolicy(ctx context.Context, policyName string, roleNam
 }
 
 // DetachRolePolicy detaches a policy from role
-func (i *IAM) DetachRolePolicy(ctx context.Context, policyName string, roleName string) error {
+func (i *IAM) DetachRolePolicy(ctx context.Context, policyArn string, roleName string) error {
 	log := log.Logger(ctx, "awsapi", "iam", "DetachRolePolicy")
-	log.WithValues("roleName", roleName, "policyName", policyName)
+	log.WithValues("roleName", roleName, "policyArn", policyArn)
 	log.V(1).Info("Initiating api call")
 
-	policyARN := aws.String(fmt.Sprintf("arn:aws:iam::%s:policy/%s", AwsAccountId, policyName))
-
 	_, err := i.Client.DetachRolePolicy(&iam.DetachRolePolicyInput{
-		PolicyArn: policyARN,
+		PolicyArn: aws.String(policyArn),
 		RoleName:  aws.String(roleName),
 	})
 	if err != nil {

--- a/pkg/awsapi/iam.go
+++ b/pkg/awsapi/iam.go
@@ -1,7 +1,7 @@
 package awsapi
 
 //go:generate mockgen -destination=mocks/mock_iamiface.go -package=mock_awsapi github.com/aws/aws-sdk-go/service/iam/iamiface IAMAPI
-//go:generate mockgen -destination=mocks/mock_iam.go -package=mock_awsapi github.com/keikoproj/iam-manager/pkg/awsapi IAMIface
+////go:generate mockgen -destination=mocks/mock_iam.go -package=mock_awsapi github.com/keikoproj/iam-manager/pkg/awsapi IAMIface
 
 import (
 	"context"

--- a/pkg/awsapi/iam_test.go
+++ b/pkg/awsapi/iam_test.go
@@ -605,47 +605,47 @@ func (s *IAMAPISuite) TestDeleteInlinePolicyFailureUnattachablePolicyDocument(c 
 
 func (s *IAMAPISuite) TestDetachRolePolicySuccess(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("VALID_ROLE")}).Times(1).Return(&iam.DetachRolePolicyOutput{}, nil)
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "VALID_ROLE")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "VALID_ROLE")
 	c.Assert(err, check.IsNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureMalformedPolicyDocument(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("MALFORMED_POLICY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeMalformedPolicyDocumentException, "", errors.New(iam.ErrCodeMalformedPolicyDocumentException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "MALFORMED_POLICY")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "MALFORMED_POLICY")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureLimitExceeded(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("TOO_MANY_REQUEST")}).Times(1).Return(nil, awserr.New(iam.ErrCodeLimitExceededException, "", errors.New(iam.ErrCodeLimitExceededException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "TOO_MANY_REQUEST")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "TOO_MANY_REQUEST")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureNoSuchEntity(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("NO_SUCH_ENTITY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", errors.New(iam.ErrCodeNoSuchEntityException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "NO_SUCH_ENTITY")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "NO_SUCH_ENTITY")
 	c.Assert(err, check.IsNil)
 }
 func (s *IAMAPISuite) TestDetachRolePolicyFailureServiceFailure(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("SERVICE_FAILURE")}).Times(1).Return(nil, awserr.New(iam.ErrCodeServiceFailureException, "", errors.New(iam.ErrCodeServiceFailureException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "SERVICE_FAILURE")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "SERVICE_FAILURE")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureUnmodififiablePolicyDocument(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("UNMODIFIABLE_POLICY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeUnmodifiableEntityException, "", errors.New(iam.ErrCodeUnmodifiableEntityException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "UNMODIFIABLE_POLICY")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "UNMODIFIABLE_POLICY")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureInvalidPolicyDocument(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("INVALID_POLICY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeInvalidInputException, "", errors.New(iam.ErrCodeInvalidInputException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "INVALID_POLICY")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "INVALID_POLICY")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *IAMAPISuite) TestDetachRolePolicyFailureUnattachablePolicyDocument(c *check.C) {
 	s.mockI.EXPECT().DetachRolePolicy(&iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/SOMETHING"), RoleName: aws.String("UNATTACHABLE_POLICY")}).Times(1).Return(nil, awserr.New(iam.ErrCodePolicyNotAttachableException, "", errors.New(iam.ErrCodePolicyNotAttachableException)))
-	err := s.mockIAM.DetachRolePolicy(s.ctx, "SOMETHING", "UNATTACHABLE_POLICY")
+	err := s.mockIAM.DetachRolePolicy(s.ctx, "arn:aws:iam::123456789012:policy/SOMETHING", "UNATTACHABLE_POLICY")
 	c.Assert(err, check.NotNil)
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -79,7 +79,7 @@ func NewK8sClientDoOrDie() *Client {
 type Iface interface {
 	IamrolesCount(ctx context.Context, ns string)
 	GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap
-	AddEvents(ctx context.Context, ns string, event *v1.Event) error
+	SetUpEventHandler(ctx context.Context) record.EventRecorder
 }
 
 //IamrolesCount function lists the "Iamrole" for a provided namespace
@@ -113,18 +113,6 @@ func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.C
 	}
 
 	return res
-}
-
-//AddEvents methods adds events
-func (c *Client) AddEvents(ctx context.Context, ns string, event *v1.Event) error {
-	log := log.Logger(ctx, "k8s", "client", "AddEvents")
-	log.WithValues("namespace", ns)
-	_, err := c.cl.CoreV1().Events(ns).Create(event)
-	if err != nil {
-		log.Error(err, "unable to create event")
-		return err
-	}
-	return nil
 }
 
 //SetUpEventHandler sets up event handler with client-go recorder instead of creating events directly

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -123,6 +123,6 @@ func (c *Client) SetUpEventHandler(ctx context.Context) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.cl.CoreV1().Events("")})
-	log.V(1).Info("Successfully add event broadcaster")
+	log.V(1).Info("Successfully added event broadcaster")
 	return eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "iam-manager"})
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"github.com/keikoproj/iam-manager/pkg/log"
 	"k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	"os"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 type Client struct {
@@ -46,10 +49,37 @@ func NewK8sClient() (*Client, error) {
 	return cl, nil
 }
 
+//NewK8sClient gets the new k8s go client
+func NewK8sClientDoOrDie() *Client {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		// Do i need to panic here?
+		//How do i test this from local?
+		//Lets get it from local config file
+		config, err = clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	dClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	cl := &Client{
+		client,
+		dClient,
+	}
+	return cl
+}
+
 //Iface defines required functions to be implemented by receivers
 type Iface interface {
 	IamrolesCount(ctx context.Context, ns string)
-	GetConfigMap(ctx context.Context, ns string, name string)
+	GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap
+	AddEvents(ctx context.Context, ns string, event *v1.Event) error
 }
 
 //IamrolesCount function lists the "Iamrole" for a provided namespace
@@ -83,4 +113,28 @@ func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.C
 	}
 
 	return res
+}
+
+//AddEvents methods adds events
+func (c *Client) AddEvents(ctx context.Context, ns string, event *v1.Event) error {
+	log := log.Logger(ctx, "k8s", "client", "AddEvents")
+	log.WithValues("namespace", ns)
+	_, err := c.cl.CoreV1().Events(ns).Create(event)
+	if err != nil {
+		log.Error(err, "unable to create event")
+		return err
+	}
+	return nil
+}
+
+//SetUpEventHandler sets up event handler with client-go recorder instead of creating events directly
+func (c *Client) SetUpEventHandler(ctx context.Context) record.EventRecorder {
+	log := log.Logger(ctx, "k8s", "client", "SetUpEventHandler")
+	//This was re-written based on job-controller in kuberentest repo
+	//For more info refer: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/job_controller.go
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.cl.CoreV1().Events("")})
+	log.V(1).Info("Successfully add event broadcaster")
+	return eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "iam-manager"})
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -34,5 +34,6 @@ func Logger(ctx context.Context, names ...string) logr.Logger {
 	if rId != nil {
 		logk = logk.WithValues("request_id", rId)
 	}
+
 	return logk
 }


### PR DESCRIPTION
close # https://github.com/keikoproj/iam-manager/issues/30

**Could you share the solution in high level?**
Adds the K8s events to respective namespace. This PR also fixes the known issue of using PolicyName instead of PolicyArn to detach policies.

**Could you share the test results?**
Following are the results from K8s events in the target namespace: Tested with attaching Managed Policy directly from AWS and iam-manager can not delete the role bcz of known PolicyName Vs PolicyARN issue which intern fixed in this same PR.

```
mtvl15367e28a:crd nmogulla$ k get events
LAST SEEN   TYPE     REASON        OBJECT                    MESSAGE
56m         Normal   Deleted       iamrole/iamrole-sample2   Successfully deleted iam role
27m         Normal   Created       iamrole/iamrole-sample2   Successfully created iam role
108s        Warning   DeleteError   iamrole/iamrole-sample2   unable to delete the role due to DeleteConflict: Cannot delete entity, must detach all policies first.
            status code: 409, request id: 0aa86198-acd9-40cb-80f8-e193c15271a8
108s        Warning   DeleteError   iamrole/iamrole-sample2   unable to delete the role due to DeleteConflict: Cannot delete entity, must detach all policies first.
            status code: 409, request id: 433a70df-4e55-4b89-81e6-1af6ec4f5682
100s        Warning   DeleteError   iamrole/iamrole-sample2   (combined from similar events): unable to delete the role due to DeleteConflict: Cannot delete entity, must detach all policies first.
            status code: 409, request id: 11cdaeff-46ef-4153-aaf0-2aff698e04eb
9s          Normal    Deleted       iamrole/iamrole-sample2   Successfully deleted iam role
mtvl15367e28a:crd nmogulla$ 
```