### PR TITLE
Delete role must check if role exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
-	golang.org/x/tools v0.0.0-20200207224406-61798d64f025 // indirect
+	golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2I
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20200207224406-61798d64f025 h1:i84/3szN87uN9jFX/jRqUbszQto2oAsFlqPf6lbR8H4=
-golang.org/x/tools v0.0.0-20200207224406-61798d64f025/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56 h1:DFtSed2q3HtNuVazwVDZ4nSRS/JrZEig0gz2BY4VNrg=
+golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
@@ -136,7 +136,6 @@ k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8 h1:q1Qvjzs/iEd
 k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d h1:Jmdtdt1ZnoGfWWIIik61Z7nKYgO3J+swQJtPYsP9wHA=
 k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible h1:U5Bt+dab9K8qaUmXINrkXO135kA11/i5Kg1RUydgaMQ=
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.3.0 h1:0VPpR+sizsiivjIfIAQH/rl8tan6jvWkS7lU+0di3lE=

--- a/hack/iam-manager-cfn.yaml
+++ b/hack/iam-manager-cfn.yaml
@@ -72,13 +72,6 @@ Resources:
               - "iam:DeletePolicy"
               - "iam:UpdateRole"
               - "iam:DeleteRole"
-              - "iam:GetRole"
-              - "iam:GetRolePolicy"
-              - "iam:GetPolicy"
-              - "iam:ListRoles"
-              - "iam:ListRolePolicies"
-              - "iam:ListAttachedRolePolicies"
-              - "iam:ListPolicies"
             Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/k8s-*"
             Condition:
               StringEquals:
@@ -90,6 +83,17 @@ Resources:
               - "iam:UntagRole"
             Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/k8s-*"
             Sid: "Allow"
+          - Effect: "Allow"
+            Action:
+              - "iam:GetRole"
+              - "iam:GetRolePolicy"
+              - "iam:GetPolicy"
+              - "iam:ListRoles"
+              - "iam:ListRolePolicies"
+              - "iam:ListAttachedRolePolicies"
+              - "iam:ListPolicies"
+            Resource: "*"
+            Sid: "AllowReadOps"
       Roles:
         - !Ref IAMManagerAccessRole
   ##### IAM Role to be assumed ####

--- a/pkg/awsapi/iam_test.go
+++ b/pkg/awsapi/iam_test.go
@@ -204,6 +204,7 @@ func (s *IAMAPISuite) TestTagRoleFailureUnattachable(c *check.C) {
 	_, err := s.mockIAM.TagRole(s.ctx, req)
 	c.Assert(err, check.NotNil)
 }
+
 //###########
 
 func (s *IAMAPISuite) TestAddPermissionBoundarySuccess(c *check.C) {
@@ -347,7 +348,7 @@ func (s *IAMAPISuite) TestUpdateRoleFailureInvalidInput(c *check.C) {
 func (s *IAMAPISuite) TestUpdateRoleAssumeRoleFailureServiceFailure(c *check.C) {
 	awsapi.ManagedPolicies = []string{"SOMETHING"}
 	s.mockI.EXPECT().UpdateRole(&iam.UpdateRoleInput{RoleName: aws.String("VALID_ROLE"), MaxSessionDuration: aws.Int64(3600), Description: aws.String("")}).Times(1).Return(nil, nil)
-	s.mockI.EXPECT().UpdateAssumeRolePolicy(&iam.UpdateAssumeRolePolicyInput{PolicyDocument: aws.String("SOMETHING"), RoleName: aws.String("VALID_ROLE")}).Times(1).Return(nil,awserr.New(iam.ErrCodeServiceFailureException, "", errors.New(iam.ErrCodeServiceFailureException)) )
+	s.mockI.EXPECT().UpdateAssumeRolePolicy(&iam.UpdateAssumeRolePolicyInput{PolicyDocument: aws.String("SOMETHING"), RoleName: aws.String("VALID_ROLE")}).Times(1).Return(nil, awserr.New(iam.ErrCodeServiceFailureException, "", errors.New(iam.ErrCodeServiceFailureException)))
 	req := awsapi.IAMRoleRequest{Name: "VALID_ROLE", PolicyName: "VALID_POLICY", PermissionPolicy: "SOMETHING", SessionDuration: 3600, TrustPolicy: "SOMETHING"}
 	_, err := s.mockIAM.UpdateRole(s.ctx, req)
 	c.Assert(err, check.NotNil)
@@ -356,7 +357,7 @@ func (s *IAMAPISuite) TestUpdateRoleAssumeRoleFailureServiceFailure(c *check.C) 
 func (s *IAMAPISuite) TestUpdateRoleAssumeRoleFailureNoSuchEntity(c *check.C) {
 	awsapi.ManagedPolicies = []string{"SOMETHING"}
 	s.mockI.EXPECT().UpdateRole(&iam.UpdateRoleInput{RoleName: aws.String("VALID_ROLE"), MaxSessionDuration: aws.Int64(3600), Description: aws.String("")}).Times(1).Return(nil, nil)
-	s.mockI.EXPECT().UpdateAssumeRolePolicy(&iam.UpdateAssumeRolePolicyInput{PolicyDocument: aws.String("SOMETHING"), RoleName: aws.String("VALID_ROLE")}).Times(1).Return(nil,awserr.New(iam.ErrCodeNoSuchEntityException, "", errors.New(iam.ErrCodeNoSuchEntityException)) )
+	s.mockI.EXPECT().UpdateAssumeRolePolicy(&iam.UpdateAssumeRolePolicyInput{PolicyDocument: aws.String("SOMETHING"), RoleName: aws.String("VALID_ROLE")}).Times(1).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", errors.New(iam.ErrCodeNoSuchEntityException)))
 	req := awsapi.IAMRoleRequest{Name: "VALID_ROLE", PolicyName: "VALID_POLICY", PermissionPolicy: "SOMETHING", SessionDuration: 3600, TrustPolicy: "SOMETHING"}
 	_, err := s.mockIAM.UpdateRole(s.ctx, req)
 	c.Assert(err, check.NotNil)
@@ -379,7 +380,6 @@ func (s *IAMAPISuite) TestUpdateRoleAssumeRoleFailureInvalidInput(c *check.C) {
 	_, err := s.mockIAM.UpdateRole(s.ctx, req)
 	c.Assert(err, check.NotNil)
 }
-
 
 //####################
 
@@ -555,11 +555,17 @@ func (s *IAMAPISuite) TestDeleteRoleFailureLimitExceeded(c *check.C) {
 	err := s.mockIAM.DeleteRole(s.ctx, "TOO_MANY_REQUEST")
 	c.Assert(err, check.NotNil)
 }
-
 func (s *IAMAPISuite) TestDeleteRoleFailureNoSuchEntity(c *check.C) {
 	s.mockI.EXPECT().DeleteRole(&iam.DeleteRoleInput{RoleName: aws.String("NO_SUCH_ENTITY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", errors.New(iam.ErrCodeNoSuchEntityException)))
 	s.mockI.EXPECT().ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{RoleName: aws.String("NO_SUCH_ENTITY")}).Times(1).Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
 	s.mockI.EXPECT().ListRolePolicies(&iam.ListRolePoliciesInput{RoleName: aws.String("NO_SUCH_ENTITY")}).Times(1).Return(&iam.ListRolePoliciesOutput{}, nil)
+
+	err := s.mockIAM.DeleteRole(s.ctx, "NO_SUCH_ENTITY")
+	c.Assert(err, check.IsNil)
+}
+
+func (s *IAMAPISuite) TestDeleteRoleFailureNoSuchEntityAssumeRole(c *check.C) {
+	s.mockI.EXPECT().ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{RoleName: aws.String("NO_SUCH_ENTITY")}).Times(1).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", errors.New(iam.ErrCodeNoSuchEntityException)))
 
 	err := s.mockIAM.DeleteRole(s.ctx, "NO_SUCH_ENTITY")
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
close https://github.com/keikoproj/iam-manager/issues/31


**Could you share the solution in high level?**
1. Make sure iam-manager role can do iam.Get* and iam.List* operations on any resources and not just handled by iam-manager
2. If ListAttachedPolicies api call returns "NoSuchEntity" - Roles doesn't exist in target account. Delete the custom resource safely.

**Could you share the test results?**
Delete the role in the target account directly created by iam-manager
Before new code:

```
2020-02-12T17:50:31.565Z	INFO	controllers.iamrole_controller.Reconcile	Start of the request	{"request_id": "e3c5f704-278e-4257-a684-94e0f45a4b8c"}
2020-02-12T17:50:31.565Z	INFO	controllers.iamrole_controller.Reconcile	Iamrole delete request	{"request_id": "e3c5f704-278e-4257-a684-94e0f45a4b8c"}
2020-02-12T17:50:31.571Z	DEBUG	awsapi.iam.DeleteRole	Initiating api call	{"request_id": "e3c5f704-278e-4257-a684-94e0f45a4b8c"}
2020-02-12T17:50:31.674Z	ERROR	awsapi.iam.DeleteRole	Unable to list attached managed policies for role	{"request_id": "e3c5f704-278e-4257-a684-94e0f45a4b8c", "error": "AccessDenied: User: arn:aws:sts::000065563193:assumed-role/k8s-cluster-iam-manager-role/kiam-kiam is not authorized to perform: iam:ListAttachedRolePolicies on resource: role k8s-dev-patterns-iksmanager-usw2-ppd-idev\n\tstatus code: 403, request id: 1d7eace6-1113-4805-a689-e74b27968d62"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
github.com/keikoproj/iam-manager/pkg/awsapi.(*IAM).DeleteRole
	/workspace/pkg/awsapi/iam.go:435
github.com/keikoproj/iam-manager/controllers.(*IamroleReconciler).Reconcile
	/workspace/controllers/iamrole_controller.go:93
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:216
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.2/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
2020-02-12T17:50:31.674Z	ERROR	controllers.iamrole_controller.Reconcile	Unable to delete the role	{"request_id": "e3c5f704-278e-4257-a684-94e0f45a4b8c", "error": "AccessDenied: User: arn:aws:sts::000065563193:assumed-role/k8s-cluster-iam-manager-role/kiam-kiam is not authorized to perform: iam:ListAttachedRolePolicies on resource: role k8s-dev-patterns-iksmanager-usw2-ppd-idev\n\tstatus code: 403, request id: 1d7eace6-1113-4805-a689-e74b27968d62"}
github.com/go-logr/zapr.(*zapLogger).Error
```
After the change:

2020-02-12T17:53:32.539Z	INFO	awsapi.iam.DeleteRole	Role doesn't exist in the target account	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90", "role_name": "k8s-dev-patterns-iksmanager-usw2-ppd-idev"}

```
2020-02-12T17:53:31.755Z	INFO	controller-runtime.controller	Starting Controller	{"controller": "iamrole"}
2020-02-12T17:53:31.755Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"ConfigMap","namespace":"iam-manager-system","name":"controller-leader-election-helper","uid":"19d6e103-3726-11ea-bd19-0225db228e40","apiVersion":"v1","resourceVersion":"586383703"}, "reason": "LeaderElection", "message": "iam-manager-controller-manager-667969fdfc-w5gpq_8af6fbd4-4dc0-11ea-8090-b2c8822ce62b became leader"}
2020-02-12T17:53:31.855Z	INFO	controller-runtime.controller	Starting workers	{"controller": "iamrole", "worker count": 1}
2020-02-12T17:53:31.856Z	INFO	controllers.iamrole_controller.Reconcile	Start of the request	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90"}
2020-02-12T17:53:31.856Z	INFO	controllers.iamrole_controller.Reconcile	Iamrole delete request	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90"}
2020-02-12T17:53:31.863Z	DEBUG	awsapi.iam.DeleteRole	Initiating api call	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90"}
2020-02-12T17:53:32.539Z	INFO	awsapi.iam.DeleteRole	Role doesn't exist in the target account	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90", "role_name": "k8s-dev-patterns-iksmanager-usw2-ppd-idev"}
2020-02-12T17:53:32.539Z	INFO	controllers.iamrole_controller.Reconcile	Removing finalizer from Iamrole	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90"}
2020-02-12T17:53:32.566Z	INFO	v1alpha1.Default	setting default version	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.568Z	INFO	v1alpha1.ValidateCreate	validate update	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.568Z	INFO	v1alpha1.validateIAMPolicy	validating IAM policy	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.568Z	DEBUG	k8s.client.IamrolesCount	list api call
2020-02-12T17:53:32.571Z	INFO	k8s.client.IamrolesCount	Total number of roles	{"count": 1}
2020-02-12T17:53:32.574Z	INFO	v1alpha1.Default	setting default version	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.576Z	INFO	v1alpha1.ValidateCreate	validate update	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.576Z	INFO	v1alpha1.validateIAMPolicy	validating IAM policy	{"name": "iksm-nmogulla-role"}
2020-02-12T17:53:32.576Z	DEBUG	k8s.client.IamrolesCount	list api call
2020-02-12T17:53:32.579Z	INFO	k8s.client.IamrolesCount	Total number of roles	{"count": 1}
2020-02-12T17:53:32.583Z	INFO	controllers.iamrole_controller.Reconcile	Successfully deleted iam role	{"request_id": "6f012521-3ee9-4a33-a1a8-3b36d9debf90"}
2020-02-12T17:53:32.583Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "iamrole", "request": "dev-patterns-iksmanager-usw2-ppd-idev/iksm-nmogulla-role"}
2020-02-12T17:53:32.583Z	INFO	controllers.iamrole_controller.Reconcile	Start of the request	{"request_id": "d3c92741-8d09-4fe1-aaf2-f51cc4194e8d"}
2020-02-12T17:53:32.583Z	DEBUG	controller-runtime.controller	Successfully Reconciled	{"controller": "iamrole", "request": "dev-patterns-iksmanager-usw2-ppd-idev/iksm-nmogulla-role"}
```

