### PR TITLE
Add validation tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ MANAGED_PERMISSION_BOUNDARY_POLICY ?= arn:aws:iam::1123456789012:role/iam-manage
 CLUSTER_NAME                ?= k8s_test_keiko
 CLUSTER_OIDC_ISSUER_URL     ?= https://google.com/OIDC
 DEFAULT_TRUST_POLICY        ?= '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"Federated": "arn:aws:iam::AWS_ACCOUNT_ID:oidc-provider/OIDC_PROVIDER"},"Action": "sts:AssumeRoleWithWebIdentity","Condition": {"StringEquals": {"OIDC_PROVIDER:sub": "system:serviceaccount:{{.NamespaceName}}:SERVICE_ACCOUNT_NAME"}}}, {"Effect": "Allow","Principal": {"AWS": ["arn:aws:iam::{{.AccountID}}:role/trust_role"]},"Action": "sts:AssumeRole"}]}'
+MAX_ROLES_ALLOWED           ?= 2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -60,6 +61,7 @@ test: mock generate fmt manifests
 	CLUSTER_NAME=$(CLUSTER_NAME) \
 	CLUSTER_OIDC_ISSUER_URL="$(CLUSTER_OIDC_ISSUER_URL)" \
 	DEFAULT_TRUST_POLICY=$(DEFAULT_TRUST_POLICY) \
+	MAX_ROLES_ALLOWED=$(MAX_ROLES_ALLOWED) \
 	go test ./... -coverprofile cover.out
 
 # Build manager binary

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -86,7 +86,7 @@ func (r *Iamrole) ValidateCreate() error {
 	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
 	log.Info("validating create request", "name", r.Name)
 
-	return r.validateIAMPolicy(false)
+	return r.validateIAMPolicy(false, wClient)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -94,7 +94,7 @@ func (r *Iamrole) ValidateUpdate(old runtime.Object) error {
 	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
 	log.Info("validate update", "name", r.Name)
 
-	return r.validateIAMPolicy(true)
+	return r.validateIAMPolicy(true, wClient)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -106,7 +106,7 @@ func (r *Iamrole) ValidateDelete() error {
 	return nil
 }
 
-func (r *Iamrole) validateIAMPolicy(isItUpdate bool) error {
+func (r *Iamrole) validateIAMPolicy(isItUpdate bool, k8sClient k8s.Iface) error {
 	log := log.Logger(context.Background(), "v1alpha1", "validateIAMPolicy")
 	log.Info("validating IAM policy", "name", r.Name)
 	var allErrs field.ErrorList
@@ -120,7 +120,7 @@ func (r *Iamrole) validateIAMPolicy(isItUpdate bool) error {
 		allErrs = append(allErrs, err)
 	}
 
-	if err := r.validateNumberOfRoles(isItUpdate); err != nil {
+	if err := r.validateNumberOfRoles(isItUpdate, k8sClient); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if len(allErrs) == 0 {
@@ -215,8 +215,8 @@ func (r *Iamrole) validateCustomResourceName() *field.Error {
 
 //Lets do a cheesy way to talk to API server
 
-func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
-	count, err := wClient.IamrolesCount(context.Background(), r.ObjectMeta.Namespace)
+func (r *Iamrole) validateNumberOfRoles(isItUpdate bool, k8sClient k8s.Iface) *field.Error {
+	count, err := k8sClient.IamrolesCount(context.Background(), r.ObjectMeta.Namespace)
 	if err != nil {
 		panic(err)
 	}

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -83,18 +83,20 @@ var _ webhook.Validator = &Iamrole{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateCreate() error {
-	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
+	ctx := context.Background()
+	log := log.Logger(ctx, "v1alpha1", "ValidateCreate")
 	log.Info("validating create request", "name", r.Name)
 
-	return r.validateIAMPolicy(false, wClient)
+	return r.validateIAMPolicy(ctx, false, wClient)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateUpdate(old runtime.Object) error {
-	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
+	ctx := context.Background()
+	log := log.Logger(ctx, "v1alpha1", "ValidateCreate")
 	log.Info("validate update", "name", r.Name)
 
-	return r.validateIAMPolicy(true, wClient)
+	return r.validateIAMPolicy(ctx, true, wClient)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -106,8 +108,8 @@ func (r *Iamrole) ValidateDelete() error {
 	return nil
 }
 
-func (r *Iamrole) validateIAMPolicy(isItUpdate bool, k8sClient k8s.Iface) error {
-	log := log.Logger(context.Background(), "v1alpha1", "validateIAMPolicy")
+func (r *Iamrole) validateIAMPolicy(ctx context.Context, isItUpdate bool, k8sClient k8s.Iface) error {
+	log := log.Logger(ctx, "v1alpha1", "validateIAMPolicy")
 	log.Info("validating IAM policy", "name", r.Name)
 	var allErrs field.ErrorList
 	if err := r.validateCustomResourceName(); err != nil {
@@ -120,7 +122,7 @@ func (r *Iamrole) validateIAMPolicy(isItUpdate bool, k8sClient k8s.Iface) error 
 		allErrs = append(allErrs, err)
 	}
 
-	if err := r.validateNumberOfRoles(isItUpdate, k8sClient); err != nil {
+	if err := r.validateNumberOfRoles(ctx, isItUpdate, k8sClient); err != nil {
 		allErrs = append(allErrs, err)
 	}
 	if len(allErrs) == 0 {
@@ -215,8 +217,8 @@ func (r *Iamrole) validateCustomResourceName() *field.Error {
 
 //Lets do a cheesy way to talk to API server
 
-func (r *Iamrole) validateNumberOfRoles(isItUpdate bool, k8sClient k8s.Iface) *field.Error {
-	count, err := k8sClient.IamrolesCount(context.Background(), r.ObjectMeta.Namespace)
+func (r *Iamrole) validateNumberOfRoles(ctx context.Context, isItUpdate bool, k8sClient k8s.Iface) *field.Error {
+	count, err := k8sClient.IamrolesCount(ctx, r.ObjectMeta.Namespace)
 	if err != nil {
 		panic(err)
 	}

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -40,7 +40,7 @@ const (
 // log is for logging in this package.
 var iamrolelog = logf.Log.WithName("iamrole-resource")
 
-var wClient *k8s.Client
+var wClient k8s.Iface
 
 func NewWClient() {
 	log := log.Logger(context.Background(), "v1alpha1", "NewWClient")

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -93,7 +93,7 @@ func (r *Iamrole) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateUpdate(old runtime.Object) error {
 	ctx := context.Background()
-	log := log.Logger(ctx, "v1alpha1", "ValidateCreate")
+	log := log.Logger(ctx, "v1alpha1", "ValidateUpdate")
 	log.Info("validate update", "name", r.Name)
 
 	return r.validateIAMPolicy(ctx, true, wClient)

--- a/api/v1alpha1/iamrole_webhook_test.go
+++ b/api/v1alpha1/iamrole_webhook_test.go
@@ -1,0 +1,89 @@
+package v1alpha1
+
+import (
+	"context"
+	"github.com/keikoproj/iam-manager/pkg/k8s/mocks"
+	"strings"
+
+	"github.com/golang/mock/gomock"
+	"github.com/keikoproj/iam-manager/internal/config"
+	"gopkg.in/check.v1"
+	"testing"
+)
+
+type WebhookSuite struct {
+	t             *testing.T
+	ctx           context.Context
+	mockCtrl      *gomock.Controller
+	mockk8sClient *mock_client.MockIface
+	iamRole       *Iamrole
+}
+
+func TestWebhookSuite(t *testing.T) {
+	check.Suite(&WebhookSuite{t: t})
+	check.TestingT(t)
+}
+
+func (s *WebhookSuite) SetUpTest(c *check.C) {
+	// Could be done in
+	err := config.LoadProperties("LOCAL")
+	c.Assert(err, check.IsNil)
+
+	s.ctx = context.Background()
+	s.mockCtrl = gomock.NewController(s.t)
+	s.mockk8sClient = mock_client.NewMockIface(s.mockCtrl)
+
+	s.iamRole = &Iamrole{}
+	// Should maybe be populated?
+	s.iamRole.Default()
+}
+
+func (s *WebhookSuite) TearDownTest(c *check.C) {
+	s.mockCtrl.Finish()
+}
+
+func (s *WebhookSuite) TestValidateCreate(c *check.C) {
+	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(
+		config.Props.MaxRolesAllowed()-1, nil)
+
+	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *WebhookSuite) TestTooManyRolesOnCreate(c *check.C) {
+	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(config.Props.MaxRolesAllowed(), nil)
+
+	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *WebhookSuite) TestTooManyRolesOnUpdate(c *check.C) {
+	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(config.Props.MaxRolesAllowed()+1, nil)
+
+	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *WebhookSuite) TestNameTooLong(c *check.C) {
+	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(0, nil)
+
+	// Limit is 52 characters
+	s.iamRole.ObjectMeta.Name = strings.Repeat("a", 56)
+
+	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *WebhookSuite) TestRestrictedPolicyResources(c *check.C) {
+	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(0, nil)
+
+	s.iamRole.Spec.PolicyDocument.Statement = []Statement{{
+		Effect: "Allowed",
+		Action: []string{"policy-resource:create"},
+		// Not allowed by config
+		Resource: []string{"arn:aws:policy-resource:*:*:res/name"},
+	}}
+
+	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	c.Assert(err, check.NotNil)
+}

--- a/api/v1alpha1/iamrole_webhook_test.go
+++ b/api/v1alpha1/iamrole_webhook_test.go
@@ -68,7 +68,7 @@ func (s *WebhookSuite) TestTooManyRolesOnCreate(c *check.C) {
 func (s *WebhookSuite) TestTooManyRolesOnUpdate(c *check.C) {
 	s.mockk8sClient.EXPECT().IamrolesCount(s.ctx, s.iamRole.ObjectMeta.Namespace).Return(config.Props.MaxRolesAllowed()+1, nil)
 
-	err := s.iamRole.validateIAMPolicy(s.ctx, false, s.mockk8sClient)
+	err := s.iamRole.validateIAMPolicy(s.ctx, true, s.mockk8sClient)
 	c.Assert(err, check.NotNil)
 }
 

--- a/internal/config/properties.go
+++ b/internal/config/properties.go
@@ -65,6 +65,14 @@ func init() {
 	log.Info("Loaded properties in init func")
 }
 
+func atoi(a string) int {
+	i, err := strconv.Atoi(a)
+	if err != nil {
+		panic(fmt.Sprintf("%s was not an int", a))
+	}
+	return i
+}
+
 func LoadProperties(env string, cm ...*v1.ConfigMap) error {
 	log := log.Logger(context.Background(), "internal.config.properties", "LoadProperties")
 
@@ -83,6 +91,7 @@ func LoadProperties(env string, cm ...*v1.ConfigMap) error {
 			clusterOIDCIssuerUrl:            os.Getenv("CLUSTER_OIDC_ISSUER_URL"),
 			defaultTrustPolicy:              os.Getenv("DEFAULT_TRUST_POLICY"),
 			iamRolePattern:                  os.Getenv("IAM_ROLE_PATTERN"),
+			maxRolesAllowed:                 atoi(os.Getenv("MAX_ROLES_ALLOWED")),
 		}
 		return nil
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -92,10 +92,10 @@ func NewK8sManagerClient(client client.Client) *Client {
 
 //Iface defines required functions to be implemented by receivers
 type Iface interface {
-	IamrolesCount(ctx context.Context, ns string)
+	IamrolesCount(ctx context.Context, ns string) (int, error)
 	GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap
 	SetUpEventHandler(ctx context.Context) record.EventRecorder
-	CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string) error
+	CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string, roleARN string) error
 }
 
 //IamrolesCount function lists the "Iamrole" for a provided namespace

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/klog"
 )
 
+//go:generate mockgen -destination=mocks/mock_clientiface.go -package=mock_client github.com/keikoproj/iam-manager/pkg/k8s Iface
+
 type Client struct {
 	cl  kubernetes.Interface
 	dCl dynamic.Interface


### PR DESCRIPTION
I haven't opened an issue for this, but I can if you'd like it to be tracked that way.

close #



**Could you share the solution in high level?**

Injects the k8s client in `ValidateCreate` and `ValidateUpdate` so we can test `validateIamPolicy` with a mock.

**Could you share the test results?**

```
go fmt ./...
/Users/aaronwebber/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/aaronwebber/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd_no_webhook/bases
KUBECONFIG=/Users/aaronwebber/.kube/config \
	LOCAL=true \
	ALLOWED_POLICY_ACTION=s3:,sts:,ec2:Describe,acm:Describe,acm:List,acm:Get,route53:Get,route53:List,route53:Create,route53:Delete,route53:Change,kms:Decrypt,kms:Encrypt,kms:ReEncrypt,kms:GenerateDataKey,kms:DescribeKey,dynamodb:,secretsmanager:GetSecretValue,es:,sqs:SendMessage,sqs:ReceiveMessage,sqs:DeleteMessage,SNS:Publish,sqs:GetQueueAttributes,sqs:GetQueueUrl \
	RESTRICTED_POLICY_RESOURCES=policy-resource \
	RESTRICTED_S3_RESOURCES=s3-resource \
	AWS_ACCOUNT_ID=123456789012 \
	AWS_REGION=us-west-2 \
	MANAGED_POLICIES=arn:aws:iam::123456789012:policy/SOMETHING \
	MANAGED_PERMISSION_BOUNDARY_POLICY=arn:aws:iam::1123456789012:role/iam-manager-permission-boundary \
	CLUSTER_NAME=k8s_test_keiko \
	CLUSTER_OIDC_ISSUER_URL="https://google.com/OIDC" \
	DEFAULT_TRUST_POLICY='{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"Federated": "arn:aws:iam::AWS_ACCOUNT_ID:oidc-provider/OIDC_PROVIDER"},"Action": "sts:AssumeRoleWithWebIdentity","Condition": {"StringEquals": {"OIDC_PROVIDER:sub": "system:serviceaccount:{{.NamespaceName}}:SERVICE_ACCOUNT_NAME"}}}, {"Effect": "Allow","Principal": {"AWS": ["arn:aws:iam::{{.AccountID}}:role/trust_role"]},"Action": "sts:AssumeRole"}]}' \
	MAX_ROLES_ALLOWED=2 \
	go test ./... -coverprofile cover.out
?   	github.com/keikoproj/iam-manager	[no test files]
ok  	github.com/keikoproj/iam-manager/api/v1alpha1	1.602s	coverage: 21.7% of statements
ok  	github.com/keikoproj/iam-manager/controllers	10.782s	coverage: 9.9% of statements
ok  	github.com/keikoproj/iam-manager/internal/config	0.859s	coverage: 66.9% of statements
ok  	github.com/keikoproj/iam-manager/internal/utils	1.288s	coverage: 84.9% of statements
ok  	github.com/keikoproj/iam-manager/pkg/awsapi	2.474s	coverage: 86.1% of statements
?   	github.com/keikoproj/iam-manager/pkg/awsapi/mocks	[no test files]
?   	github.com/keikoproj/iam-manager/pkg/k8s	[no test files]
?   	github.com/keikoproj/iam-manager/pkg/k8s/mocks	[no test files]
?   	github.com/keikoproj/iam-manager/pkg/log	[no test files]
ok  	github.com/keikoproj/iam-manager/pkg/validation	1.988s	coverage: 87.4% of statements
```