### PR TITLE
Ensure the ServiceAccount IRSA annotation is in place on each reconciliation loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go mod download
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
+COPY constants/ constants/
 COPY controllers/ controllers/
 COPY pkg pkg/
 COPY internal internal/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ OSNAME           ?= $(shell uname -s | tr A-Z a-z)
 KUBEBUILDER_VER  ?= 2.2.0
 KUBEBUILDER_ARCH ?= amd64
 
+# Set the Go build environment to build for AMD64 no matter what
+DOCKER_ARCH      ?= linux/amd64
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -114,7 +117,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build --platform $(DOCKER_ARCH) . -t ${IMG}
 
 # Push the docker image
 docker-push:

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,0 +1,21 @@
+package constants
+
+// Global constants
+const (
+	// InlinePolicyName defines user managed inline policy
+	InlinePolicyName = "custom"
+
+	// IamManagerNamespaceName is the namespace name where iam-manager controllers are running
+	IamManagerNamespaceName = "iam-manager-system"
+
+	// IamManagerConfigMapName is the config map name for iam-manager namespace
+	IamManagerConfigMapName = "iam-manager-iamroles-v1alpha1-configmap"
+
+	OIDCAudience = "sts.amazonaws.com"
+
+	IRSAAnnotation = "iam.amazonaws.com/irsa-service-account"
+
+	ServiceAccountRoleAnnotation = "eks.amazonaws.com/role-arn"
+
+	IamManagerPrivilegedNamespaceAnnotation = "iammanager.keikoproj.io/privileged"
+)

--- a/controllers/iamrole_controller.go
+++ b/controllers/iamrole_controller.go
@@ -102,13 +102,14 @@ func (r *IamroleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if iamRole.Status.State != iammanagerv1alpha1.PolicyNotAllowed {
 			//Get the roleName from status
 			roleName := iamRole.Status.RoleName
-			if err := r.IAMClient.DeleteRole(ctx, roleName); err != nil {
-				log.Error(err, "Unable to delete the role")
-				//i got to fix this
-				r.UpdateStatus(ctx, &iamRole, iammanagerv1alpha1.IamroleStatus{RetryCount: iamRole.Status.RetryCount + 1, LastUpdatedTimestamp: metav1.Now(), ErrorDescription: err.Error(), State: iammanagerv1alpha1.Error})
-				r.Recorder.Event(&iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.Error), "unable to delete the role due to "+err.Error())
-
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			if roleName != "" {
+				if err := r.IAMClient.DeleteRole(ctx, roleName); err != nil {
+					log.Error(err, "Unable to delete the role")
+					//i got to fix this
+					r.UpdateStatus(ctx, &iamRole, iammanagerv1alpha1.IamroleStatus{RetryCount: iamRole.Status.RetryCount + 1, LastUpdatedTimestamp: metav1.Now(), ErrorDescription: err.Error(), State: iammanagerv1alpha1.Error})
+					r.Recorder.Event(&iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.Error), "unable to delete the role due to "+err.Error())
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				}
 			}
 		}
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -1,17 +1,5 @@
 package config
 
-// Global constants
-const (
-	// InlinePolicyName defines user managed inline policy
-	InlinePolicyName = "custom"
-
-	// IamManagerNamespaceName is the namespace name where iam-manager controllers are running
-	IamManagerNamespaceName = "iam-manager-system"
-
-	// IamManagerConfigMapName is the config map name for iam-manager namespace
-	IamManagerConfigMapName = "iam-manager-iamroles-v1alpha1-configmap"
-)
-
 const (
 	// iam policy action prefix
 	propertyIamPolicyWhitelist = "iam.policy.action.prefix.whitelist"
@@ -57,14 +45,6 @@ const (
 
 	//propertyDefaultTrustPolicy can be used to provide default trust policy
 	propertyDefaultTrustPolicy = "iam.default.trust.policy"
-)
 
-const (
 	separator = ","
-
-	OIDCAudience = "sts.amazonaws.com"
-
-	IRSAAnnotation = "iam.amazonaws.com/irsa-service-account"
-
-	IamManagerPrivilegedNamespaceAnnotation = "iammanager.keikoproj.io/privileged"
 )

--- a/internal/config/properties.go
+++ b/internal/config/properties.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
 	"github.com/keikoproj/iam-manager/pkg/k8s"
 	"github.com/keikoproj/iam-manager/pkg/log"
@@ -54,7 +55,7 @@ func init() {
 		log.Error(err, "unable to create new k8s client")
 		panic(err)
 	}
-	res := k8sClient.GetConfigMap(context.Background(), IamManagerNamespaceName, IamManagerConfigMapName)
+	res := k8sClient.GetConfigMap(context.Background(), constants.IamManagerNamespaceName, constants.IamManagerConfigMapName)
 
 	// load properties into a global variable
 	err = LoadProperties("", res)
@@ -277,7 +278,7 @@ func (p *Properties) DefaultTrustPolicy() string {
 
 func RunConfigMapInformer(ctx context.Context) {
 	log := log.Logger(context.Background(), "internal.config.properties", "RunConfigMapInformer")
-	cmInformer := k8s.GetConfigMapInformer(ctx, IamManagerNamespaceName, IamManagerConfigMapName)
+	cmInformer := k8s.GetConfigMapInformer(ctx, constants.IamManagerNamespaceName, constants.IamManagerConfigMapName)
 	cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: updateProperties,
 	},

--- a/internal/utils/oidc.go
+++ b/internal/utils/oidc.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/keikoproj/iam-manager/api/v1alpha1"
-	"github.com/keikoproj/iam-manager/internal/config"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/pkg/log"
 
 	"net/url"
@@ -77,7 +77,17 @@ func parseURL(ctx context.Context, idpUrl string) (string, error) {
 	return hostName, nil
 }
 
-//ParseIRSAAnnotation parses IAM role to see if the role to be used in IRSA method
+// ParseIRSAAnnotation parses IAM role to see if the role to be used in IRSA method.
+//
+// Returns back both a boolean to indicate whether or not the IRSA system should be used,
+// and also returns back the name of the ServiceAccount that should be referenced based
+// on the annotation value.
 func ParseIRSAAnnotation(ctx context.Context, iamRole *v1alpha1.Iamrole) (bool, string) {
-	return parseAnnotations(ctx, config.IRSAAnnotation, iamRole.Annotations)
+	log := log.Logger(ctx, "internal.utils.oidc", "ParseIRSAAnnotation")
+	value, err := getAnnotation(ctx, constants.IRSAAnnotation, iamRole.Annotations)
+	if err != nil {
+		log.V(1).Info("IRSA Annotation not found", "err", err)
+		return false, ""
+	}
+	return true, value
 }

--- a/internal/utils/oidc_test.go
+++ b/internal/utils/oidc_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/keikoproj/iam-manager/api/v1alpha1"
-	"github.com/keikoproj/iam-manager/internal/config"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/internal/utils"
 	"gopkg.in/check.v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +48,7 @@ func (s *OIDCTestSuite) TestParseIRSAAnnotationValid(c *check.C) {
 			Name:      "iam-role",
 			Namespace: "k8s-namespace-dev",
 			Annotations: map[string]string{
-				config.IRSAAnnotation: "default",
+				constants.IRSAAnnotation: "default",
 			},
 		},
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/golang/mock/gomock"
 	"github.com/keikoproj/iam-manager/api/v1alpha1"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/internal/config"
 	"github.com/keikoproj/iam-manager/internal/utils"
 	"gopkg.in/check.v1"
@@ -456,7 +457,7 @@ func (s *UtilsTestSuite) TestGetTrustPolicyWithIRSAAnnotation(c *check.C) {
 			Name:      "iam-role",
 			Namespace: "k8s-namespace-dev",
 			Annotations: map[string]string{
-				config.IRSAAnnotation: "default",
+				constants.IRSAAnnotation: "default",
 			},
 		},
 	}
@@ -500,7 +501,7 @@ func (s *UtilsTestSuite) TestGetTrustPolicyWithIRSAAnnotationAndServiceRoleInReq
 			Name:      "iam-role",
 			Namespace: "k8s-namespace-dev",
 			Annotations: map[string]string{
-				config.IRSAAnnotation: "default",
+				constants.IRSAAnnotation: "default",
 			},
 		},
 		Spec: v1alpha1.IamroleSpec{

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	iammanagerv1alpha1 "github.com/keikoproj/iam-manager/api/v1alpha1"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/controllers"
 	"github.com/keikoproj/iam-manager/internal/config"
 	"github.com/keikoproj/iam-manager/internal/utils"
@@ -123,7 +124,7 @@ func handleOIDCSetupForIRSA(ctx context.Context, iamClient *awsapi.IAM) error {
 			return err
 		}
 
-		err = iamClient.CreateOIDCProvider(ctx, config.Props.OIDCIssuerUrl(), config.OIDCAudience, thumbprint)
+		err = iamClient.CreateOIDCProvider(ctx, config.Props.OIDCIssuerUrl(), constants.OIDCAudience, thumbprint)
 		if err != nil {
 			log.Error(err, "unable to setup OIDC with the url", "url", config.Props.OIDCIssuerUrl())
 			return err

--- a/pkg/awsapi/iam_test.go
+++ b/pkg/awsapi/iam_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/golang/mock/gomock"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/internal/config"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
 	"github.com/keikoproj/iam-manager/pkg/awsapi/mocks"
@@ -927,7 +928,7 @@ func (s *IAMAPISuite) TestCreateOIDCProviderSuccess(c *check.C) {
 		OpenIDConnectProviderArn: aws.String("valid_arn"),
 	}, nil)
 
-	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", config.OIDCAudience, "valid_thumbprint")
+	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", constants.OIDCAudience, "valid_thumbprint")
 	c.Assert(err, check.IsNil)
 }
 
@@ -939,7 +940,7 @@ func (s *IAMAPISuite) TestCreateOIDCProviderInvalidInput(c *check.C) {
 	}
 	s.mockI.EXPECT().CreateOpenIDConnectProvider(input).Times(1).Return(nil, awserr.New(iam.ErrCodeInvalidInputException, "", errors.New(iam.ErrCodeInvalidInputException)))
 
-	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", config.OIDCAudience, "invalid_thumbprint")
+	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", constants.OIDCAudience, "invalid_thumbprint")
 	c.Assert(err, check.NotNil)
 }
 
@@ -951,7 +952,7 @@ func (s *IAMAPISuite) TestCreateOIDCProviderAlreadyExists(c *check.C) {
 	}
 	s.mockI.EXPECT().CreateOpenIDConnectProvider(input).Times(1).Return(nil, awserr.New(iam.ErrCodeEntityAlreadyExistsException, "", errors.New(iam.ErrCodeEntityAlreadyExistsException)))
 
-	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", config.OIDCAudience, "already_exists_thumbprint")
+	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", constants.OIDCAudience, "already_exists_thumbprint")
 	c.Assert(err, check.IsNil)
 }
 
@@ -963,7 +964,7 @@ func (s *IAMAPISuite) TestCreateOIDCProviderLimitExceeded(c *check.C) {
 	}
 	s.mockI.EXPECT().CreateOpenIDConnectProvider(input).Times(1).Return(nil, awserr.New(iam.ErrCodeLimitExceededException, "", errors.New(iam.ErrCodeLimitExceededException)))
 
-	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", config.OIDCAudience, "limit_exceeded_thumbprint")
+	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", constants.OIDCAudience, "limit_exceeded_thumbprint")
 	c.Assert(err, check.NotNil)
 }
 
@@ -975,6 +976,6 @@ func (s *IAMAPISuite) TestCreateOIDCProviderServiceFailure(c *check.C) {
 	}
 	s.mockI.EXPECT().CreateOpenIDConnectProvider(input).Times(1).Return(nil, awserr.New(iam.ErrCodeServiceFailureException, "", errors.New(iam.ErrCodeServiceFailureException)))
 
-	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", config.OIDCAudience, "failure_thumbprint")
+	err := s.mockIAM.CreateOIDCProvider(s.ctx, "https://server.example.com", constants.OIDCAudience, "failure_thumbprint")
 	c.Assert(err, check.NotNil)
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,16 +1,12 @@
 package k8s
 
+//go:generate mockgen -destination=mocks/mock_clientiface.go -package=mock_k8s sigs.k8s.io/controller-runtime/pkg/client Client
+
 import (
 	"context"
 	"fmt"
 	"github.com/keikoproj/iam-manager/pkg/log"
-	"k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
-
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -19,8 +15,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 type Client struct {
@@ -97,6 +98,9 @@ type Iface interface {
 	SetUpEventHandler(ctx context.Context) record.EventRecorder
 	GetNamespace(ctx context.Context, ns string) *v1.Namespace
 	CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string) error
+	EnsureServiceAccount(ctx context.Context, req ServiceAccountRequest) error
+	PatchServiceAccountAnnotation(ctx context.Context, saName string, ns string, annotation string, value string) error
+	GetServiceAccount(ctx context.Context, saName string, ns string) (*v1.ServiceAccount, error)
 }
 
 //IamrolesCount function lists the "Iamrole" for a provided namespace

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -7,13 +7,11 @@ import (
 	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/pkg/log"
 	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//ServiceAcountRequest struct
+// ServiceAccountRequest struct
 type ServiceAccountRequest struct {
 	Namespace          string
 	IamRoleARN         string
@@ -26,7 +24,7 @@ type ServiceAccountRequest struct {
 // Current functionality is limited - but I am to increase the complexity and control
 // of how this mapping works, which and I want to keep as little complexity in the
 // CreateOrUpdateServiceAccount function as possible.
-func (c *Client) EnsureServiceAccount(ctx context.Context, req ServiceAccountRequest) error {
+func (c *Client) EnsureServiceAccount(ctx context.Context, req ServiceAccountRequest) (*corev1.ServiceAccount, error) {
 	log := log.Logger(ctx, "pkg.k8s", "rbac", "EnsureServiceAccount")
 	log = log.WithValues("request", req)
 
@@ -34,72 +32,61 @@ func (c *Client) EnsureServiceAccount(ctx context.Context, req ServiceAccountReq
 	// ServiceAccount at one point, and should now _remove_ the annotation from it or not.
 
 	// First thing, check if the SA exists already. If it does, we will avoid a failed Create call.
-	sa, _ := c.GetServiceAccount(ctx, req.ServiceAccountName, req.Namespace)
+	sa, err := c.GetOrCreateServiceAccount(ctx, req.ServiceAccountName, req.Namespace)
+	if err != nil {
+		log.Error(err, "Unable to get or create ServiceAccount!")
+		return nil, err
+	}
 	log.V(1).Info("Got existing SA", "serviceaccount", sa)
 
 	// If the SA exists, let's check its annotations now. If they match, we don't need to do any
 	// more work and we can return!
-	if sa != nil {
-		// Get the annotation value. Check it against the desired Role ARN.
-		currentVal, _ := sa.Annotations[constants.ServiceAccountRoleAnnotation]
+	currentVal, _ := sa.Annotations[constants.ServiceAccountRoleAnnotation]
 
-		// Does it match? If so, we're done here. Return.
-		if currentVal == req.IamRoleARN {
-			log.V(1).Info("Existing ServiceAccount looks good")
-			return nil
-		}
-
-		// Log this out because its a useful datapoint
-		log.Info(fmt.Sprintf(
-			`Found existing ServiceAccount - but %s annotation
-			 does not match expected value.`, constants.ServiceAccountRoleAnnotation))
+	// Does it match? If so, we're done here. Return.
+	if currentVal == req.IamRoleARN {
+		log.V(1).Info("Existing ServiceAccount looks good")
+		return sa, nil
 	}
 
-	// At this point, we know the user wants us to ensure the ServiceAccount has the right Annotation applied to it.
-	err := c.CreateOrUpdateServiceAccount(ctx, req.ServiceAccountName, req.Namespace, req.IamRoleARN)
+	// Log this out because its a useful datapoint
+	log.Info(fmt.Sprintf(
+		`Found existing ServiceAccount - but %s annotation
+		 does not match expected value.`, constants.ServiceAccountRoleAnnotation))
+
+	// At this point, patch the ServiceAccount to set the annotation that we expect
+	sa, err = c.PatchServiceAccountAnnotation(ctx, sa.Name, sa.Namespace, constants.ServiceAccountRoleAnnotation, req.IamRoleARN)
 	if err != nil {
-		return err
+		msg := fmt.Sprintf("Failed to update service account %s due to %v", sa.Name, err)
+		log.Error(err, msg)
+		return nil, errors.New(msg)
 	}
 
 	// Everything worked out!
-	return nil
+	return sa, nil
 }
 
-//CreateOrUpdateServiceAccount adds the service account or updates the account if it already exists.
-func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string, roleARN string) error {
-	log := log.Logger(ctx, "pkg.k8s", "rbac", "CreateOrUpdateServiceAccount")
+// GetOrCreateServiceAccount will get an SA and return it, or create it (and return it) if necessary
+func (c *Client) GetOrCreateServiceAccount(ctx context.Context, saName string, ns string) (*corev1.ServiceAccount, error) {
+	log := log.Logger(ctx, "pkg.k8s", "rbac", "GetOrCreateServiceAccount")
+	log = log.WithValues("name", saName, "namespace", ns)
 
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: ns,
-			Annotations: map[string]string{
-				constants.ServiceAccountRoleAnnotation: roleARN,
-			},
-		},
+	// First try to get an existing SA...
+	sa, err := c.GetServiceAccount(ctx, saName, ns)
+	if sa != nil {
+		return sa, nil
 	}
-
-	log.V(1).Info("Service Account creation is in progress")
-	err := c.rCl.Create(ctx, sa)
 	if err != nil {
-		// If the error was _not_ an already-exists issue, then fail quickly.
-		if !apierr.IsAlreadyExists(err) {
-			msg := fmt.Sprintf("Failed to create service account %s in namespace %s due to %v", sa.Name, ns, err)
-			log.Error(err, msg)
-			return errors.New(msg)
-		}
-
-		log.Info("Service account already exists. Trying to update", "serviceAccount", sa.Name, "namespace", ns)
-		//err = c.rCl.Update(ctx, sa)
-		err = c.PatchServiceAccountAnnotation(ctx, saName, ns, constants.ServiceAccountRoleAnnotation, roleARN)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to update service account %s due to %v", sa.Name, err)
-			log.Error(err, msg)
-			return errors.New(msg)
-		}
+		log.Info("Did not find existing ServiceAccount, will create one instead")
 	}
-	log.Info("Service account got created successfully", "serviceAccount", sa.Name, "namespace", ns)
-	return nil
+
+	// If we got here, then we need to create the SA instead...
+	sa, err = c.CreateServiceAccount(ctx, saName, ns)
+	if err != nil {
+		log.Error(err, "Unable to create ServiceAccount")
+		return nil, err
+	}
+	return sa, nil
 }
 
 // GetServiceAccount returns back a ServiceAccount resource if it exists in K8S
@@ -107,8 +94,27 @@ func (c *Client) GetServiceAccount(ctx context.Context, saName string, ns string
 	log := log.Logger(ctx, "pkg.k8s", "rbac", "GetServiceAccount")
 	log = log.WithValues("name", saName, "namespace", ns)
 
-	sa := &corev1.ServiceAccount{}
-	err := c.rCl.Get(ctx, client.ObjectKey{Namespace: ns, Name: saName}, sa)
+	sa, err := c.Cl.CoreV1().ServiceAccounts(ns).Get(saName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return sa, nil
+}
+
+// CreateServiceAccount returns back a ServiceAccount resource if it exists in K8S
+func (c *Client) CreateServiceAccount(ctx context.Context, saName string, ns string) (*corev1.ServiceAccount, error) {
+	log := log.Logger(ctx, "pkg.k8s", "rbac", "CreateServiceAccount")
+	log = log.WithValues("name", saName, "namespace", ns)
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: ns,
+		},
+	}
+
+	sa, err := c.Cl.CoreV1().ServiceAccounts(ns).Create(sa)
 	if err != nil {
 		return nil, err
 	}
@@ -119,20 +125,15 @@ func (c *Client) GetServiceAccount(ctx context.Context, saName string, ns string
 // PatchServiceAccountAnnotation will issue a patch call to the K8S API to update an annotation on a
 // particular ServiceAccount. We use a patch here so that we do not need to worry about mutating any
 // other state on a ServiceAccount object, nor do we have to worry about any out-of-order update issues.
-func (c *Client) PatchServiceAccountAnnotation(ctx context.Context, saName string, ns string, annotation string, value string) error {
+func (c *Client) PatchServiceAccountAnnotation(ctx context.Context, saName string, ns string, annotation string, value string) (*corev1.ServiceAccount, error) {
 	log := log.Logger(ctx, "pkg.k8s", "rbac", "PatchServiceAccountAnnotation")
 	log = log.WithValues("annotation", annotation, "value", value)
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s": "%s"}}}`, annotation, value))
 
 	log.V(1).Info("Applying patch for ServiceAccount", "patch", string(patch))
-	err := c.rCl.Patch(ctx, &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      saName,
-		},
-	}, client.RawPatch(types.StrategicMergePatchType, patch))
+	sa, err := c.Cl.CoreV1().ServiceAccounts(ns).Patch(saName, types.StrategicMergePatchType, patch)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return sa, nil
 }

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -4,37 +4,94 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/keikoproj/iam-manager/constants"
 	"github.com/keikoproj/iam-manager/pkg/log"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//CreateServiceAccount adds the service account
+//ServiceAcountRequest struct
+type ServiceAccountRequest struct {
+	Namespace          string
+	IamRoleARN         string
+	ServiceAccountName string
+}
+
+// EnsureServiceAccount decomposes a ServiceAccountRequest into the right behavior and
+// desired target state of a ServiceAccount<->Iamrole mapping, and implements that.
+//
+// Current functionality is limited - but I am to increase the complexity and control
+// of how this mapping works, which and I want to keep as little complexity in the
+// CreateOrUpdateServiceAccount function as possible.
+func (c *Client) EnsureServiceAccount(ctx context.Context, req ServiceAccountRequest) error {
+	log := log.Logger(ctx, "pkg.k8s", "rbac", "EnsureServiceAccount")
+	log = log.WithValues("request", req)
+
+	// TODO: Implement a check in the future to figure out whether or not we _were supposed_ to manage the
+	// ServiceAccount at one point, and should now _remove_ the annotation from it or not.
+
+	// First thing, check if the SA exists already. If it does, we will avoid a failed Create call.
+	sa, _ := c.GetServiceAccount(ctx, req.ServiceAccountName, req.Namespace)
+	log.V(1).Info("Got existing SA", "serviceaccount", sa)
+
+	// If the SA exists, let's check its annotations now. If they match, we don't need to do any
+	// more work and we can return!
+	if sa != nil {
+		// Get the annotation value. Check it against the desired Role ARN.
+		currentVal, _ := sa.Annotations[constants.ServiceAccountRoleAnnotation]
+
+		// Does it match? If so, we're done here. Return.
+		if currentVal == req.IamRoleARN {
+			log.V(1).Info("Existing ServiceAccount looks good")
+			return nil
+		}
+
+		// Log this out because its a useful datapoint
+		log.Info(fmt.Sprintf(
+			`Found existing ServiceAccount - but %s annotation
+			 does not match expected value.`, constants.ServiceAccountRoleAnnotation))
+	}
+
+	// At this point, we know the user wants us to ensure the ServiceAccount has the right Annotation applied to it.
+	err := c.CreateOrUpdateServiceAccount(ctx, req.ServiceAccountName, req.Namespace, req.IamRoleARN)
+	if err != nil {
+		return err
+	}
+
+	// Everything worked out!
+	return nil
+}
+
+//CreateOrUpdateServiceAccount adds the service account or updates the account if it already exists.
 func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string, roleARN string) error {
 	log := log.Logger(ctx, "pkg.k8s", "rbac", "CreateOrUpdateServiceAccount")
 
 	sa := &corev1.ServiceAccount{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
 			Namespace: ns,
 			Annotations: map[string]string{
-				"eks.amazonaws.com/role-arn": roleARN,
+				constants.ServiceAccountRoleAnnotation: roleARN,
 			},
 		},
 	}
-	//_, err := c.cl.CoreV1().ServiceAccounts(ns).Create(sa)
+
 	log.V(1).Info("Service Account creation is in progress")
 	err := c.rCl.Create(ctx, sa)
 	if err != nil {
+		// If the error was _not_ an already-exists issue, then fail quickly.
 		if !apierr.IsAlreadyExists(err) {
 			msg := fmt.Sprintf("Failed to create service account %s in namespace %s due to %v", sa.Name, ns, err)
 			log.Error(err, msg)
 			return errors.New(msg)
 		}
+
 		log.Info("Service account already exists. Trying to update", "serviceAccount", sa.Name, "namespace", ns)
-		err = c.rCl.Update(ctx, sa)
+		//err = c.rCl.Update(ctx, sa)
+		err = c.PatchServiceAccountAnnotation(ctx, saName, ns, constants.ServiceAccountRoleAnnotation, roleARN)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to update service account %s due to %v", sa.Name, err)
 			log.Error(err, msg)
@@ -42,5 +99,40 @@ func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, saName string
 		}
 	}
 	log.Info("Service account got created successfully", "serviceAccount", sa.Name, "namespace", ns)
+	return nil
+}
+
+// GetServiceAccount returns back a ServiceAccount resource if it exists in K8S
+func (c *Client) GetServiceAccount(ctx context.Context, saName string, ns string) (*corev1.ServiceAccount, error) {
+	log := log.Logger(ctx, "pkg.k8s", "rbac", "GetServiceAccount")
+	log = log.WithValues("name", saName, "namespace", ns)
+
+	sa := &corev1.ServiceAccount{}
+	err := c.rCl.Get(ctx, client.ObjectKey{Namespace: ns, Name: saName}, sa)
+	if err != nil {
+		return nil, err
+	}
+
+	return sa, nil
+}
+
+// PatchServiceAccountAnnotation will issue a patch call to the K8S API to update an annotation on a
+// particular ServiceAccount. We use a patch here so that we do not need to worry about mutating any
+// other state on a ServiceAccount object, nor do we have to worry about any out-of-order update issues.
+func (c *Client) PatchServiceAccountAnnotation(ctx context.Context, saName string, ns string, annotation string, value string) error {
+	log := log.Logger(ctx, "pkg.k8s", "rbac", "PatchServiceAccountAnnotation")
+	log = log.WithValues("annotation", annotation, "value", value)
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s": "%s"}}}`, annotation, value))
+
+	log.V(1).Info("Applying patch for ServiceAccount", "patch", string(patch))
+	err := c.rCl.Patch(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      saName,
+		},
+	}, client.RawPatch(types.StrategicMergePatchType, patch))
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/k8s/rbac_test.go
+++ b/pkg/k8s/rbac_test.go
@@ -1,0 +1,69 @@
+package k8s_test
+
+import (
+	"context"
+	"github.com/golang/mock/gomock"
+	"github.com/keikoproj/iam-manager/pkg/k8s"
+	mock_k8s "github.com/keikoproj/iam-manager/pkg/k8s/mocks"
+	"gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+type RBACSuite struct {
+	t          *testing.T
+	ctx        context.Context
+	mockCtrl   *gomock.Controller
+	mockClient *mock_k8s.MockClient
+	mockRbac   *k8s.Client
+}
+
+func TestRBACTestSuite(t *testing.T) {
+	check.Suite(&RBACSuite{t: t})
+	check.TestingT(t)
+}
+
+func (s *RBACSuite) SetUpTest(c *check.C) {
+	s.ctx = context.Background()
+	s.mockCtrl = gomock.NewController(s.t)
+	s.mockClient = mock_k8s.NewMockClient(s.mockCtrl)
+	s.mockRbac = k8s.NewK8sManagerClient(s.mockClient)
+}
+
+func (s *RBACSuite) TearDownTest(c *check.C) {
+	s.mockCtrl.Finish()
+}
+
+func (s *RBACSuite) TestEnsureServiceAccountAlreadyExistsAndIsCorrect(c *check.C) {
+	req := k8s.ServiceAccountRequest{
+		Namespace:          "test-ns",
+		IamRoleARN:         "arn:aws:...",
+		ServiceAccountName: "test-sa",
+	}
+	// Returning nil here triggers the behavior where a ServiceAccount object is indeed returned by the
+	// GetServiceAccount function. However that object will be empty (it will have no annotations), so
+	// we'll also be mocking out the
+	s.mockClient.EXPECT().Get(s.ctx, client.ObjectKey{Namespace: "test-ns", Name: "test-sa"}, gomock.Any()).Times(1).Return(nil)
+	err := s.mockRbac.EnsureServiceAccount(s.ctx, req)
+	c.Assert(err, check.IsNil)
+}
+
+//############
+
+// Failing:
+//
+// /private/var/folders/dm/b5by_qw91nd0ctdjbvggzgr40000gq/T/___RBACSuite_TestPatchServiceAccountAnnotation_in_github_com_keikoproj_iam_manager_pkg_k8s__3_.test -test.v -test.paniconexit0 -check.f ^\QTestPatchServiceAccountAnnotation\E$ -check.vv
+// rbac.go:128: Unexpected call to *mock_k8s.MockClient.Patch([context.Background &ServiceAccount{ObjectMeta:{test-sa  test-ns    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},Secrets:[]ObjectReference{},ImagePullSecrets:[]LocalObjectReference{},AutomountServiceAccountToken:nil,} 0x1400012b5f0]) at /Users/diranged/go/src/github.com/keikoproj/iam-manager/pkg/k8s/rbac.go:128 because:
+// expected call at /Users/diranged/go/src/github.com/keikoproj/iam-manager/pkg/k8s/rbac_test.go:49 doesn't match the argument at index 2.
+// Got: &{application/strategic-merge-patch+json [123 34 109 101 116 97 100 97 116 97 34 58 123 34 97 110 110 111 116 97 116 105 111 110 115 34 58 123 34 102 97 107 101 45 97 110 110 111 116 97 116 105 111 110 34 58 32 34 118 97 108 117 101 34 125 125 125]} (*client.patch)
+// Want: is equal to &{application/strategic-merge-patch+json [123 34 109 101 116 97 100 97 116 97 34 58 123 34 97 110 110 111 116 97 116 105 111 110 115 34 58 123 34 102 97 107 101 45 97 110 110 111 116 97 116 105 111 110 34 58 34 32 34 118 97 108 117 101 34 125 125 125]} (*client.patch)
+// controller.go:269: missing call(s) to *mock_k8s.MockClient.Patch(is equal to context.Background (*context.emptyCtx), is anything, is equal to &{application/strategic-merge-patch+json [123 34 109 101 116 97 100 97 116 97 34 58 123 34 97 110 110 111 116 97 116 105 111 110 115 34 58 123 34 102 97 107 101 45 97 110 110 111 116 97 116 105 111 110 34 58 34 32 34 118 97 108 117 101 34 125 125 125]} (*client.patch)) /Users/diranged/go/src/github.com/keikoproj/iam-manager/pkg/k8s/rbac_test.go:49
+// controller.go:269: aborting test due to missing call(s)
+func (s *RBACSuite) TestPatchServiceAccountAnnotation(c *check.C) {
+	patch := []byte(`{"metadata":{"annotations":{"fake-annotation":" "value"}}}`)
+	s.mockClient.EXPECT().Patch(s.ctx, gomock.Any(), client.RawPatch(types.StrategicMergePatchType, patch)).Times(1).Return(nil)
+	err := s.mockRbac.PatchServiceAccountAnnotation(s.ctx, "test-sa", "test-ns", "fake-annotation", "value")
+	c.Assert(err, check.IsNil)
+
+}


### PR DESCRIPTION
close #86 

**What did I want?**

The original code only created the `ServiceAccount` resource and set the `eks.amazonaws.com/role-arn` annotation once - at creation time. If that failed for any reason, or became out of date, the controller did not fix it for you. The controllers job should be to constantly ensure that the desired state of the world is correct, including the ServiceAccount link.

**What did I do?**

A few things.. primarily I added in the "create/update service account" into the handler for state=ready. While I was here, I wanted to introduce some logic to get the current state of the ServiceAccount so that we can make a decision as to whether or not we need to apply a change or not. Finally, in order to do that cleanly, I moved some constants around because there were package import issues.

**Why the new constants package?**

The original constants were stored in `internal/config` .. but `internal/config/config.go` depends on `k8s/client.go`. That made it impossible to import a constant into the `k8s` package. I have pulled the true global constants out of the `internal/config` package and put them into a truly isolated `constants` package.

**Whats up with the `EnsureServiceAccount` function?**

The existing `CreateOrUpdateServiceAccount` function is good in that it is fairly simple. I wanted to add some logic to prevent making create/update calls if they are unnecessary, and I did not want to introduce that complexity into the existing function. 