### PR TITLE
Rename package pkg/log to pkg/logging to avoid the many variable collisions

### DIFF
--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/keikoproj/iam-manager/pkg/k8s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/keikoproj/iam-manager/internal/config"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/k8s"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 const (
@@ -44,7 +44,7 @@ var iamrolelog = logf.Log.WithName("iamrole-resource")
 var wClient *k8s.Client
 
 func NewWClient() {
-	log := log.Logger(context.Background(), "v1alpha1", "NewWClient")
+	log := logging.Logger(context.Background(), "v1alpha1", "NewWClient")
 	log.Info("loading k8s client")
 	k8sClient, err := k8s.NewK8sClient()
 	if err != nil {
@@ -68,7 +68,7 @@ var _ webhook.Defaulter = &Iamrole{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Iamrole) Default() {
-	log := log.Logger(context.Background(), "v1alpha1", "Default")
+	log := logging.Logger(context.Background(), "v1alpha1", "Default")
 	log.Info("setting default version", "name", r.Name)
 
 	//Set the default value for Version
@@ -84,7 +84,7 @@ var _ webhook.Validator = &Iamrole{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateCreate() error {
-	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
+	log := logging.Logger(context.Background(), "v1alpha1", "ValidateCreate")
 	log.Info("validating create request", "name", r.Name)
 
 	return r.validateIAMPolicy(false)
@@ -92,7 +92,7 @@ func (r *Iamrole) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateUpdate(old runtime.Object) error {
-	log := log.Logger(context.Background(), "v1alpha1", "ValidateCreate")
+	log := logging.Logger(context.Background(), "v1alpha1", "ValidateCreate")
 	log.Info("validate update", "name", r.Name)
 
 	return r.validateIAMPolicy(true)
@@ -100,7 +100,7 @@ func (r *Iamrole) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *Iamrole) ValidateDelete() error {
-	log := log.Logger(context.Background(), "v1alpha1", "ValidateDelete")
+	log := logging.Logger(context.Background(), "v1alpha1", "ValidateDelete")
 	log.Info("validate delete", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object deletion.
@@ -108,7 +108,7 @@ func (r *Iamrole) ValidateDelete() error {
 }
 
 func (r *Iamrole) validateIAMPolicy(isItUpdate bool) error {
-	log := log.Logger(context.Background(), "v1alpha1", "validateIAMPolicy")
+	log := logging.Logger(context.Background(), "v1alpha1", "validateIAMPolicy")
 	log.Info("validating IAM policy", "name", r.Name)
 	var allErrs field.ErrorList
 	if err := r.validateCustomResourceName(); err != nil {

--- a/controllers/iamrole_controller.go
+++ b/controllers/iamrole_controller.go
@@ -40,7 +40,7 @@ import (
 	"github.com/keikoproj/iam-manager/internal/utils"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
 	"github.com/keikoproj/iam-manager/pkg/k8s"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 	"github.com/keikoproj/iam-manager/pkg/validation"
 )
 
@@ -71,7 +71,7 @@ func (r *IamroleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}()
 
 	ctx := context.WithValue(context.Background(), requestId, uuid.New())
-	log := log.Logger(ctx, "controllers", "iamrole_controller", "Reconcile")
+	log := logging.Logger(ctx, "controllers", "iamrole_controller", "Reconcile")
 	log.WithValues("iamrole", req.NamespacedName)
 	log.Info("Start of the request")
 
@@ -126,7 +126,7 @@ func (r *IamroleReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 //HandleReconcile function handles all the reconcile
 func (r *IamroleReconciler) HandleReconcile(ctx context.Context, req ctrl.Request, iamRole *iammanagerv1alpha1.Iamrole) (ctrl.Result, error) {
-	log := log.Logger(ctx, "controllers", "iamrole_controller", "HandleReconcile")
+	log := logging.Logger(ctx, "controllers", "iamrole_controller", "HandleReconcile")
 	log = log.WithValues("iam_role_cr", iamRole.Name)
 	log.Info("state of the custom resource ", "state", iamRole.Status.State)
 	ns := v1.Namespace{}
@@ -276,7 +276,7 @@ func (r *IamroleReconciler) HandleReconcile(ctx context.Context, req ctrl.Reques
 
 //ConstructInput function constructs input for
 func (r *IamroleReconciler) ConstructCreateIAMRoleInput(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, roleName string) (*awsapi.IAMRoleRequest, *iammanagerv1alpha1.IamroleStatus, error) {
-	log := log.Logger(ctx, "controllers", "iamrole_controller", "ConstructInput")
+	log := logging.Logger(ctx, "controllers", "iamrole_controller", "ConstructInput")
 	log.WithValues("iamrole", iamRole.Name)
 	role, _ := json.Marshal(iamRole.Spec.PolicyDocument)
 
@@ -346,7 +346,7 @@ type StatusUpdatePredicate struct {
 
 // Update implements default UpdateEvent filter for validating generation change
 func (StatusUpdatePredicate) Update(e event.UpdateEvent) bool {
-	log := log.Logger(context.Background(), "controllers", "iamrole_controller", "HandleReconcile")
+	log := logging.Logger(context.Background(), "controllers", "iamrole_controller", "HandleReconcile")
 	if e.MetaOld == nil {
 		log.Error(nil, "Update event has no old metadata", "event", e)
 		return false
@@ -382,7 +382,7 @@ func (r *IamroleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 //UpdateStatus function updates the status based on the process step
 func (r *IamroleReconciler) UpdateStatus(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, status iammanagerv1alpha1.IamroleStatus, requeueTime ...float64) (ctrl.Result, error) {
-	log := log.Logger(ctx, "controllers", "iamrole_controller", "UpdateStatus")
+	log := logging.Logger(ctx, "controllers", "iamrole_controller", "UpdateStatus")
 	log.WithValues("iamrole", fmt.Sprintf("k8s-%s", iamRole.ObjectMeta.Namespace))
 	if status.RoleARN == "" {
 		status.RoleARN = iamRole.Status.RoleARN
@@ -417,7 +417,7 @@ func (r *IamroleReconciler) UpdateStatus(ctx context.Context, iamRole *iammanage
 
 //UpdateMeta function updates the metadata (mostly finalizers in this case)
 func (r *IamroleReconciler) UpdateMeta(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole) {
-	log := log.Logger(ctx, "controllers", "iamrole_controller", "UpdateMeta")
+	log := logging.Logger(ctx, "controllers", "iamrole_controller", "UpdateMeta")
 	log = log.WithValues("iam_role_cr", iamRole.ObjectMeta.Name)
 
 	if err := r.Update(ctx, iamRole); err != nil {

--- a/internal/config/properties.go
+++ b/internal/config/properties.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
 	"github.com/keikoproj/iam-manager/pkg/k8s"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 var (
@@ -40,7 +40,7 @@ type Properties struct {
 }
 
 func init() {
-	log := log.Logger(context.Background(), "internal.config.properties", "init")
+	log := logging.Logger(context.Background(), "internal.config.properties", "init")
 
 	if os.Getenv("LOCAL") != "" {
 		err := LoadProperties("LOCAL")
@@ -69,7 +69,7 @@ func init() {
 }
 
 func LoadProperties(env string, cm ...*v1.ConfigMap) error {
-	log := log.Logger(context.Background(), "internal.config.properties", "LoadProperties")
+	log := logging.Logger(context.Background(), "internal.config.properties", "LoadProperties")
 
 	// for local testing
 	if env != "" {
@@ -295,7 +295,7 @@ func (p *Properties) DefaultTrustPolicy() string {
 }
 
 func RunConfigMapInformer(ctx context.Context) {
-	log := log.Logger(context.Background(), "internal.config.properties", "RunConfigMapInformer")
+	log := logging.Logger(context.Background(), "internal.config.properties", "RunConfigMapInformer")
 	cmInformer := k8s.GetConfigMapInformer(ctx, IamManagerNamespaceName, IamManagerConfigMapName)
 	cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: updateProperties,
@@ -307,7 +307,7 @@ func RunConfigMapInformer(ctx context.Context) {
 }
 
 func updateProperties(old, new interface{}) {
-	log := log.Logger(context.Background(), "internal.config.properties", "updateProperties")
+	log := logging.Logger(context.Background(), "internal.config.properties", "updateProperties")
 	oldCM := old.(*v1.ConfigMap)
 	newCM := new.(*v1.ConfigMap)
 	if oldCM.ResourceVersion == newCM.ResourceVersion {

--- a/internal/utils/oidc.go
+++ b/internal/utils/oidc.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/keikoproj/iam-manager/api/v1alpha1"
 	"github.com/keikoproj/iam-manager/internal/config"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 //GetIdpServerCertThumbprint gets the Thumbbprint of the certificate which will be used to generate OIDC tokens
 //This was taken from AWS repo https://github.com/aws/containers-roadmap/issues/23#issuecomment-530887531 comment
 // https://play.golang.org/p/iSobu11ahUi
 func GetIdpServerCertThumbprint(ctx context.Context, url string) (string, error) {
-	log := log.Logger(ctx, "internal.utils.oidc", "GetIdpServerCertThumbprint")
+	log := logging.Logger(ctx, "internal.utils.oidc", "GetIdpServerCertThumbprint")
 	log.Info("Calculating Idp Server cert Thumbprint")
 
 	thumbprint := ""
@@ -55,7 +55,7 @@ func GetIdpServerCertThumbprint(ctx context.Context, url string) (string, error)
 
 //parseURL verifies the url and returns hostname and port
 func parseURL(ctx context.Context, idpUrl string) (string, error) {
-	log := log.Logger(ctx, "internal.utils.oidc", "parseURL")
+	log := logging.Logger(ctx, "internal.utils.oidc", "parseURL")
 	resp, err := url.Parse(idpUrl)
 	if err != nil {
 		log.Error(err, "unable to parse the idp url")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,16 +9,16 @@ import (
 	"strings"
 	"text/template"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	iammanagerv1alpha1 "github.com/keikoproj/iam-manager/api/v1alpha1"
 	"github.com/keikoproj/iam-manager/internal/config"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 //GetTrustPolicy constructs trust policy
 func GetTrustPolicy(ctx context.Context, role *iammanagerv1alpha1.Iamrole) (string, error) {
-	log := log.Logger(ctx, "internal.utils.utils", "GetTrustPolicy")
+	log := logging.Logger(ctx, "internal.utils.utils", "GetTrustPolicy")
 	tPolicy := role.Spec.AssumeRolePolicyDocument
 
 	var statements []iammanagerv1alpha1.TrustPolicyStatement
@@ -87,7 +87,7 @@ type Fields struct {
 
 //DefaultTrustPolicy converts the config map variable string to v1alpha1.AssumeRolePolicyDocument and executes Go Template if any
 func DefaultTrustPolicy(ctx context.Context, trustPolicyDoc string, ns string) (*iammanagerv1alpha1.AssumeRolePolicyDocument, error) {
-	log := log.Logger(ctx, "internal.utils.utils", "defaultTrustPolicy")
+	log := logging.Logger(ctx, "internal.utils.utils", "defaultTrustPolicy")
 	if trustPolicyDoc == "" {
 		msg := "default trust policy is not provided in the config map. Request must provide trust policy in the CR"
 		err := errors.New(msg)
@@ -130,7 +130,7 @@ func DefaultTrustPolicy(ctx context.Context, trustPolicyDoc string, ns string) (
 // the supplied iam.role.pattern. This pattern can be customized by the
 // end-user.
 func GenerateRoleName(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, props config.Properties, ns *v1.Namespace) (string, error) {
-	log := log.Logger(ctx, "internal.utils.utils", "GenerateRoleName")
+	log := logging.Logger(ctx, "internal.utils.utils", "GenerateRoleName")
 
 	//For already created roles - don't change the name but pick it up from the status
 	if iamRole.Status.RoleName != "" {
@@ -171,7 +171,7 @@ func GenerateRoleName(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, 
 //parseAnnotations parses annotations attached to iam role resource and returns the value if found
 // input: Name of the annotation, IamRole resource
 func parseAnnotations(ctx context.Context, name string, annotations map[string]string) (bool, string) {
-	log := log.Logger(ctx, "internal.utils.utils", "ParseIRSAAnnotation")
+	log := logging.Logger(ctx, "internal.utils.utils", "ParseIRSAAnnotation")
 	flag := false
 	response := ""
 	//Look for the specific annotation in iam role CR

--- a/main.go
+++ b/main.go
@@ -26,13 +26,14 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	// +kubebuilder:scaffold:imports
 	iammanagerv1alpha1 "github.com/keikoproj/iam-manager/api/v1alpha1"
 	"github.com/keikoproj/iam-manager/controllers"
 	"github.com/keikoproj/iam-manager/internal/config"
 	"github.com/keikoproj/iam-manager/internal/utils"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
 	"github.com/keikoproj/iam-manager/pkg/k8s"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 var (
@@ -56,8 +57,8 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "Enable Debug?")
 	flag.Parse()
 
-	log.New()
-	log := log.Logger(context.Background(), "main", "setup")
+	logging.New()
+	log := logging.Logger(context.Background(), "main", "setup")
 
 	go config.RunConfigMapInformer(context.Background())
 
@@ -112,7 +113,7 @@ func main() {
 
 //handleOIDCSetupForIRSA will be used to setup the OIDC in AWS IAM
 func handleOIDCSetupForIRSA(ctx context.Context, iamClient *awsapi.IAM) error {
-	log := log.Logger(ctx, "main", "handleOIDCSetupForIRSA")
+	log := logging.Logger(ctx, "main", "handleOIDCSetupForIRSA")
 
 	//Creating OIDC provider if config map has an entry
 

--- a/pkg/awsapi/eks.go
+++ b/pkg/awsapi/eks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 type EKSIface interface {
@@ -34,7 +34,7 @@ func NewEKS(region string) *EKS {
 
 //DescribeCluster function provides cluster info
 func (e *EKS) DescribeCluster(ctx context.Context, clusterName string) (*eks.DescribeClusterOutput, error) {
-	log := log.Logger(ctx, "awsapi", "eks", "DescribeCluster")
+	log := logging.Logger(ctx, "awsapi", "eks", "DescribeCluster")
 	log.WithValues("clusterName", clusterName)
 	log.V(1).Info("Initiating api call")
 

--- a/pkg/awsapi/iam.go
+++ b/pkg/awsapi/iam.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 //IAMIface defines interface methods
@@ -82,7 +82,7 @@ func NewIAM(region string) *IAM {
 
 // EnsureRole ensures that a role exists, and that it has the appropriate configuration
 func (i *IAM) EnsureRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "EnsureRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "EnsureRole")
 	log = log.WithValues("roleName", req.Name)
 
 	// Get the role, or create it.
@@ -142,7 +142,7 @@ func (i *IAM) EnsureRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleRespo
 // GetOrCreateRole will try to create a new IAM Role in AWS. If it exists already, it will
 // use that role. In either case we return back an IAMRoleResponse{} object.
 func (i *IAM) GetOrCreateRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "GetOrCreateRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "GetOrCreateRole")
 	log = log.WithValues("roleName", req.Name)
 
 	// Try getting the role. If the role already exists, just return it.
@@ -176,7 +176,7 @@ func (i *IAM) GetOrCreateRole(ctx context.Context, req IAMRoleRequest) (*IAMRole
 
 //VerifyTags function verifies the tags attached to the role
 func (i *IAM) VerifyTags(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "VerifyTags")
+	log := logging.Logger(ctx, "awsapi", "iam", "VerifyTags")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 
@@ -214,7 +214,7 @@ func (i *IAM) VerifyTags(ctx context.Context, req IAMRoleRequest) (*IAMRoleRespo
 
 //TagRole tags role with appropriate tags
 func (i *IAM) TagRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "TagRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "TagRole")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 
@@ -262,7 +262,7 @@ func (i *IAM) TagRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse
 
 //AddPermissionBoundary adds permission boundary to the existing roles
 func (i *IAM) AddPermissionBoundary(ctx context.Context, req IAMRoleRequest) error {
-	log := log.Logger(ctx, "awsapi", "iam", "AddPermissionBoundary")
+	log := logging.Logger(ctx, "awsapi", "iam", "AddPermissionBoundary")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 	input := &iam.PutRolePermissionsBoundaryInput{
@@ -308,7 +308,7 @@ func (i *IAM) AddPermissionBoundary(ctx context.Context, req IAMRoleRequest) err
 
 //UpdateRole updates role
 func (i *IAM) UpdateRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "UpdateRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "UpdateRole")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 	input := &iam.UpdateRoleInput{
@@ -383,7 +383,7 @@ func (i *IAM) UpdateRole(ctx context.Context, req IAMRoleRequest) (*IAMRoleRespo
 
 //AttachInlineRolePolicy function attaches inline policy to the role
 func (i *IAM) AttachInlineRolePolicy(ctx context.Context, req IAMRoleRequest) (*IAMRoleResponse, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "AttachInlineRolePolicy")
+	log := logging.Logger(ctx, "awsapi", "iam", "AttachInlineRolePolicy")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 	input := &iam.PutRolePolicyInput{
@@ -422,7 +422,7 @@ func (i *IAM) AttachInlineRolePolicy(ctx context.Context, req IAMRoleRequest) (*
 
 // CreateRole will try to create an IAM Role, or return back Nil if it can not be created
 func (i *IAM) CreateRole(ctx context.Context, req IAMRoleRequest) (*iam.CreateRoleOutput, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "CreateRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "CreateRole")
 	log = log.WithValues("roleName", req.Name)
 
 	input := &iam.CreateRoleInput{
@@ -468,7 +468,7 @@ func (i *IAM) CreateRole(ctx context.Context, req IAMRoleRequest) (*iam.CreateRo
 
 //GetRole gets the role from aws iam
 func (i *IAM) GetRole(ctx context.Context, req IAMRoleRequest) (*iam.GetRoleOutput, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "GetRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "GetRole")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 	// First get the iam role policy on the AWS IAM side
@@ -493,7 +493,7 @@ func (i *IAM) GetRole(ctx context.Context, req IAMRoleRequest) (*iam.GetRoleOutp
 
 //GetRolePolicy gets the role from aws iam
 func (i *IAM) GetRolePolicy(ctx context.Context, req IAMRoleRequest) (*string, error) {
-	log := log.Logger(ctx, "awsapi", "iam", "GetRolePolicy")
+	log := logging.Logger(ctx, "awsapi", "iam", "GetRolePolicy")
 	log = log.WithValues("roleName", req.Name)
 	log.V(1).Info("Initiating api call")
 	// First get the iam role policy on the AWS IAM side
@@ -531,7 +531,7 @@ func (i *IAM) GetRolePolicy(ctx context.Context, req IAMRoleRequest) (*string, e
 
 // AttachManagedRolePolicy function attaches managed policy to the role
 func (i *IAM) AttachManagedRolePolicy(ctx context.Context, policyArn string, roleName string) error {
-	log := log.Logger(ctx, "awsapi", "iam", "AttachManagedRolePolicy")
+	log := logging.Logger(ctx, "awsapi", "iam", "AttachManagedRolePolicy")
 	log = log.WithValues("roleName", roleName, "policyName", policyArn)
 	log.V(1).Info("Initiating api call")
 
@@ -567,7 +567,7 @@ func (i *IAM) AttachManagedRolePolicy(ctx context.Context, policyArn string, rol
 
 //DeleteRole function deletes the role in the account
 func (i *IAM) DeleteRole(ctx context.Context, roleName string) error {
-	log := log.Logger(ctx, "awsapi", "iam", "DeleteRole")
+	log := logging.Logger(ctx, "awsapi", "iam", "DeleteRole")
 	log = log.WithValues("roleName", roleName)
 	log.V(1).Info("Initiating api call")
 
@@ -640,7 +640,7 @@ func (i *IAM) DeleteRole(ctx context.Context, roleName string) error {
 
 //DeleteInlinePolicy function deletes inline policy
 func (i *IAM) DeleteInlinePolicy(ctx context.Context, policyName string, roleName string) error {
-	log := log.Logger(ctx, "awsapi", "iam", "DeleteInlinePolicy")
+	log := logging.Logger(ctx, "awsapi", "iam", "DeleteInlinePolicy")
 	log = log.WithValues("roleName", roleName, "policyName", policyName)
 	log.V(1).Info("Initiating api call")
 
@@ -680,7 +680,7 @@ func (i *IAM) DeleteInlinePolicy(ctx context.Context, policyName string, roleNam
 
 // DetachRolePolicy detaches a policy from role
 func (i *IAM) DetachRolePolicy(ctx context.Context, policyArn string, roleName string) error {
-	log := log.Logger(ctx, "awsapi", "iam", "DetachRolePolicy")
+	log := logging.Logger(ctx, "awsapi", "iam", "DetachRolePolicy")
 	log = log.WithValues("roleName", roleName, "policyArn", policyArn)
 	log.V(1).Info("Initiating api call")
 
@@ -718,7 +718,7 @@ func (i *IAM) DetachRolePolicy(ctx context.Context, policyArn string, roleName s
 
 //CreateOIDCProvider creates OIDC IDP provider with AWS IAM
 func (i *IAM) CreateOIDCProvider(ctx context.Context, url string, aud string, certThumpPrint string) error {
-	log := log.Logger(ctx, "awsapi.iam", "CreateOIDCProvider")
+	log := logging.Logger(ctx, "awsapi.iam", "CreateOIDCProvider")
 	log = log.WithValues("url", url, "aud", aud)
 	log.V(1).Info("Creating OIDC Provider with AWS IAM")
 

--- a/pkg/awsapi/sts.go
+++ b/pkg/awsapi/sts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 type STSIface interface {
@@ -34,7 +34,7 @@ func NewSTS(region string) *STS {
 
 // GetAccountID loads aws accountID from sts caller identity
 func (i *STS) GetAccountID(ctx context.Context) (string, error) {
-	log := log.Logger(context.Background(), "awsapi", "iam", "GetAccountID")
+	log := logging.Logger(context.Background(), "awsapi", "iam", "GetAccountID")
 
 	// get caller identity in order to fetch aws account ID
 	result, err := i.Client.GetCallerIdentity(&sts.GetCallerIdentityInput{})

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -14,14 +15,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/klog"
-
-	"github.com/keikoproj/iam-manager/pkg/log"
-	"k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 type Client struct {
@@ -102,7 +102,7 @@ type Iface interface {
 
 //IamrolesCount function lists the "Iamrole" for a provided namespace
 func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
-	log := log.Logger(ctx, "k8s", "client", "IamrolesCount")
+	log := logging.Logger(ctx, "k8s", "client", "IamrolesCount")
 	log.WithValues("namespace", ns)
 	log.V(1).Info("list api call")
 	iamCR := schema.GroupVersionResource{
@@ -121,7 +121,7 @@ func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 }
 
 func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap {
-	log := log.Logger(ctx, "k8s", "client", "GetConfigMap")
+	log := logging.Logger(ctx, "k8s", "client", "GetConfigMap")
 	log.WithValues("namespace", ns)
 	log.Info("Retrieving config map")
 	res, err := c.cl.CoreV1().ConfigMaps(ns).Get(name, metav1.GetOptions{})
@@ -135,7 +135,7 @@ func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.C
 
 //GetNamespace gets the namespace metadata. This will be used to validate if the namespace is annotated for privileged namespace.
 func (c *Client) GetNamespace(ctx context.Context, ns string) (*v1.Namespace, error) {
-	log := log.Logger(ctx, "k8s", "client", "GetNamespace")
+	log := logging.Logger(ctx, "k8s", "client", "GetNamespace")
 	log.WithValues("namespace", ns)
 	log.Info("Retrieving Namespace")
 	resp := &v1.Namespace{}
@@ -158,7 +158,7 @@ func (c *Client) ClientInterface() kubernetes.Interface {
 
 // GetConfigMapInformer returns shared informer for given config map
 func GetConfigMapInformer(ctx context.Context, nsName string, cmName string) cache.SharedIndexInformer {
-	log := log.Logger(context.Background(), "pkg.k8s.client", "GetConfigMapInformer")
+	log := logging.Logger(context.Background(), "pkg.k8s.client", "GetConfigMapInformer")
 	clientset, err := NewK8sClient()
 	if err != nil {
 		log.Error(err, "failed to get clientset")
@@ -176,7 +176,7 @@ func GetConfigMapInformer(ctx context.Context, nsName string, cmName string) cac
 
 //SetUpEventHandler sets up event handler with client-go recorder instead of creating events directly
 func (c *Client) SetUpEventHandler(ctx context.Context) record.EventRecorder {
-	log := log.Logger(ctx, "k8s", "client", "SetUpEventHandler")
+	log := logging.Logger(ctx, "k8s", "client", "SetUpEventHandler")
 	//This was re-written based on job-controller in kuberentest repo
 	//For more info refer: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/job_controller.go
 	eventBroadcaster := record.NewBroadcaster()
@@ -188,7 +188,7 @@ func (c *Client) SetUpEventHandler(ctx context.Context) record.EventRecorder {
 
 //GetServiceAccount returns the service account with a given name in a given namespace
 func (c *Client) GetServiceAccount(ctx context.Context, ns string, name string) *v1.ServiceAccount {
-	log := log.Logger(ctx, "k8s", "client", "GetServiceAccount")
+	log := logging.Logger(ctx, "k8s", "client", "GetServiceAccount")
 	log.WithValues("namespace", ns)
 	log.Info("Retrieving service account")
 	sa := &v1.ServiceAccount{}

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -9,12 +9,12 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
 //CreateServiceAccount adds the service account
 func (c *Client) CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string, roleARN string, regionalEndpointDisabled bool) error {
-	log := log.Logger(ctx, "pkg.k8s", "rbac", "CreateOrUpdateServiceAccount")
+	log := logging.Logger(ctx, "pkg.k8s", "rbac", "CreateOrUpdateServiceAccount")
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,4 +1,4 @@
-package log
+package logging
 
 import (
 	"context"

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -10,20 +10,19 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	"github.com/keikoproj/iam-manager/api/v1alpha1"
 	"github.com/keikoproj/iam-manager/internal/config"
 	"github.com/keikoproj/iam-manager/internal/utils"
 	"github.com/keikoproj/iam-manager/pkg/awsapi"
-	"github.com/keikoproj/iam-manager/pkg/log"
+	"github.com/keikoproj/iam-manager/pkg/logging"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 //ValidateIAMPolicyAction validates policy action
 func ValidateIAMPolicyAction(ctx context.Context, pDoc v1alpha1.PolicyDocument) *field.Error {
-	log := log.Logger(ctx, "pkg.validation", "ValidateIAMPolicyAction")
+	log := logging.Logger(ctx, "pkg.validation", "ValidateIAMPolicyAction")
 
 	//Check the incoming policy actions
 	for _, statement := range pDoc.Statement {
@@ -73,7 +72,7 @@ func ValidateIAMPolicyAction(ctx context.Context, pDoc v1alpha1.PolicyDocument) 
 
 //ValidateIAMPolicyResource validates policy resource
 func ValidateIAMPolicyResource(ctx context.Context, pDoc v1alpha1.PolicyDocument) *field.Error {
-	log := log.Logger(ctx, "pkg.validation", "ValidateIAMPolicyResource")
+	log := logging.Logger(ctx, "pkg.validation", "ValidateIAMPolicyResource")
 
 	//Check the incoming policy resource
 	for _, statement := range pDoc.Statement {
@@ -103,7 +102,7 @@ func ValidateIAMPolicyResource(ctx context.Context, pDoc v1alpha1.PolicyDocument
 
 //CompareRole function compares input role to target role
 func CompareRole(ctx context.Context, request awsapi.IAMRoleRequest, targetRole *iam.GetRoleOutput, targetRolePolicy string) bool {
-	log := log.Logger(ctx, "pkg.validation", "ComparePolicy")
+	log := logging.Logger(ctx, "pkg.validation", "ComparePolicy")
 
 	// Step 1: Compare the permission policy
 	if !ComparePermissionPolicy(ctx, request.PermissionPolicy, targetRolePolicy) {
@@ -145,7 +144,7 @@ func CompareRoleIRSA(ctx context.Context, sa *v1.ServiceAccount, props config.Pr
 
 //ComparePermissionPolicy compares role policy from request and response
 func ComparePermissionPolicy(ctx context.Context, request string, target string) bool {
-	log := log.Logger(ctx, "pkg.validation", "ComparePermissionPolicy")
+	log := logging.Logger(ctx, "pkg.validation", "ComparePermissionPolicy")
 
 	d, _ := url.QueryUnescape(target)
 	dest := v1alpha1.PolicyDocument{}
@@ -170,7 +169,7 @@ func ComparePermissionPolicy(ctx context.Context, request string, target string)
 
 //CompareAssumeRolePolicy compares assume role policy from request and response
 func CompareAssumeRolePolicy(ctx context.Context, request string, target string) bool {
-	log := log.Logger(ctx, "pkg.validation", "CompareAssumeRolePolicy")
+	log := logging.Logger(ctx, "pkg.validation", "CompareAssumeRolePolicy")
 
 	a, _ := url.QueryUnescape(target)
 	destAssume := v1alpha1.AssumeRolePolicyDocument{}
@@ -195,7 +194,7 @@ func CompareAssumeRolePolicy(ctx context.Context, request string, target string)
 
 //CompareTags compares tags from request and response
 func CompareTags(ctx context.Context, request map[string]string, target []*iam.Tag) bool {
-	log := log.Logger(ctx, "pkg.validation", "CompareTags")
+	log := logging.Logger(ctx, "pkg.validation", "CompareTags")
 	log.Info("start CompareTags")
 
 	var targetTags map[string]string


### PR DESCRIPTION
This PR renames the `log` package to `logging` to avoid collisions.

As obviated by the line `log := log.Logger...` -- the variable `log` is the same as the package `log`, which causes a name collision and could have unintended side effects.