### PR TITLE
Simplify the usage of ParseIRSAAnnotation

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -22,11 +22,8 @@ func GetTrustPolicy(ctx context.Context, role *iammanagerv1alpha1.Iamrole) (stri
 	var statements []iammanagerv1alpha1.TrustPolicyStatement
 
 	// Is it IRSA use case
-	flag, saName := ParseIRSAAnnotation(ctx, role)
-
-	//Construct AssumeRoleWithWebIdentity
-	if flag {
-
+	// Construct AssumeRoleWithWebIdentity
+	if flag, saName := ParseIRSAAnnotation(ctx, role); flag {
 		hostPath := fmt.Sprintf("%s", strings.TrimPrefix(config.Props.OIDCIssuerUrl(), "https://"))
 		statement := iammanagerv1alpha1.TrustPolicyStatement{
 			Effect: "Allow",


### PR DESCRIPTION
This PR simplifies the use of `ParseIRSAAnnotation` and reduces the scope of `flag` and `saName` variables.

No functional code changes.

Similar to #94

Signed-off-by: Delyan Raychev <delyanr+github@gmail.com>
