### PR TITLE
workflow: Adding lint before unit test

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -1,4 +1,4 @@
-name: unit-test
+name: lint-and-unit-test
 
 on:
   push:
@@ -7,6 +7,23 @@ on:
     branches: [ master ]
 
 jobs:
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+
   unit-test:
     name: unit-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces a `lint` GitHub workflow job, which runs before unit testing.