### PR TITLE
Update hack directory with new CRD API structure

### DIFF
--- a/hack/iam-manager-cfn.yaml
+++ b/hack/iam-manager-cfn.yaml
@@ -15,10 +15,11 @@ Parameters:
   ParamK8sTrustRole:
     Description: Role to be assumed in case of kiam
     Type: String
+    Default: ""
   ParamK8sClusterName:
     Description: Cluster Name to be included in the names
     Type: String
-    Deafult: "cluster"
+    Default: "cluster"
   AllowedPolicyList:
     Description: Allowed IAM policy list
     Type: CommaDelimitedList

--- a/hack/iam-manager.yaml
+++ b/hack/iam-manager.yaml
@@ -6,7 +6,7 @@ metadata:
     control-plane: controller-manager
   name: iam-manager-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -16,28 +16,6 @@ metadata:
     app: iam-manager
   name: iamroles.iammanager.keikoproj.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    description: current state of the iam role
-    name: State
-    type: string
-  - JSONPath: .status.roleName
-    description: Name of the role
-    name: RoleName
-    type: string
-  - JSONPath: .status.retryCount
-    description: Retry count
-    name: RetryCount
-    type: integer
-  - JSONPath: .status.lastUpdatedTimestamp
-    description: last updated iam role timestamp
-    format: date-time
-    name: LastUpdatedTimestamp
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: time passed since iamrole creation
-    name: Age
-    type: date
   group: iammanager.keikoproj.io
   names:
     kind: Iamrole
@@ -47,168 +25,165 @@ spec:
     - iam
     singular: iamrole
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Iamrole is the Schema for the iamroles API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IamroleSpec defines the desired state of Iamrole
-          properties:
-            AssumeRolePolicyDocument:
-              properties:
-                Statement:
-                  description: Statement allows list of TrustPolicyStatement objects
-                  items:
-                    description: TrustPolicy struct holds Trust policy
-                    properties:
-                      Action:
-                        description: Action can be performed
-                        type: string
-                      Condition:
-                        description: Condition struct holds Condition
-                        properties:
-                          StringEquals:
-                            additionalProperties:
-                              type: string
-                            description: StringEquals can be used to define Equal
-                              condition
-                            type: object
-                          StringLike:
-                            additionalProperties:
-                              type: string
-                            description: StringLike can be used for regex as supported
-                              by AWS
-                            type: object
-                        type: object
-                      Effect:
-                        description: Effect allowed/denied
-                        enum:
-                        - Allow
-                        - Deny
-                        type: string
-                      Principal:
-                        description: Principal struct holds AWS principal
-                        properties:
-                          AWS:
-                            description: StringOrStrings type accepts one string or
-                              multiple strings
-                            items:
-                              type: string
-                            type: array
-                          Federated:
-                            type: string
-                          Service:
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                Version:
-                  description: Version specifies IAM policy version By default, this
-                    value is "2012-10-17"
-                  type: string
-              type: object
-            PolicyDocument:
-              description: PolicyDocument type defines IAM policy struct
-              properties:
-                Statement:
-                  description: Statement allows list of statement object
-                  items:
-                    description: Statement type defines the AWS IAM policy statement
-                    properties:
-                      Action:
-                        description: Action allowed on specific resources
-                        items:
-                          type: string
-                        type: array
-                      Effect:
-                        description: Effect allowed/denied
-                        enum:
-                        - Allow
-                        - Deny
-                        type: string
-                      Resource:
-                        description: Resources defines target resources which IAM
-                          policy will be applied
-                        items:
-                          type: string
-                        type: array
-                      Sid:
-                        description: Sid is an optional field which describes the
-                          specific statement action
-                        type: string
-                    required:
-                    - Action
-                    - Effect
-                    - Resource
-                    type: object
-                  type: array
-                Version:
-                  description: Version specifies IAM policy version By default, this
-                    value is "2012-10-17"
-                  type: string
-              required:
-              - Statement
-              type: object
-            RoleName:
-              description: RoleName can be passed only for privileged namespaces.
-                This will be respected only during new iamrole creation and will be
-                ignored during iamrole update Please check the documentation for more
-                on how to configure privileged namespace using annotation for iam-manager
-              type: string
-          required:
-          - PolicyDocument
-          type: object
-        status:
-          description: IamroleStatus defines the observed state of Iamrole
-          properties:
-            errorDescription:
-              description: ErrorDescription in case of error
-              type: string
-            lastUpdatedTimestamp:
-              description: LastUpdatedTimestamp represents the last time the iam role
-                has been modified
-              format: date-time
-              type: string
-            retryCount:
-              description: RetryCount in case of error
-              type: integer
-            roleARN:
-              description: RoleARN represents the ARN of an IAM role
-              type: string
-            roleID:
-              description: RoleID represents the unique ID of the role which can be
-                used in S3 policy etc
-              type: string
-            roleName:
-              description: RoleName represents the name of the iam role created in
-                AWS
-              type: string
-            state:
-              description: State of the resource
-              type: string
-          required:
-          - retryCount
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: Iamrole is the Schema for the iamroles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IamroleSpec defines the desired state of Iamrole
+            properties:
+              AssumeRolePolicyDocument:
+                properties:
+                  Statement:
+                    description: Statement allows list of TrustPolicyStatement objects
+                    items:
+                      description: TrustPolicy struct holds Trust policy
+                      properties:
+                        Action:
+                          description: Action can be performed
+                          type: string
+                        Condition:
+                          description: Condition struct holds Condition
+                          properties:
+                            StringEquals:
+                              additionalProperties:
+                                type: string
+                              description: StringEquals can be used to define Equal
+                                condition
+                              type: object
+                            StringLike:
+                              additionalProperties:
+                                type: string
+                              description: StringLike can be used for regex as supported
+                                by AWS
+                              type: object
+                          type: object
+                        Effect:
+                          description: Effect allowed/denied
+                          enum:
+                          - Allow
+                          - Deny
+                          type: string
+                        Principal:
+                          description: Principal struct holds AWS principal
+                          properties:
+                            AWS:
+                              description: StringOrStrings type accepts one string or
+                                multiple strings
+                              items:
+                                type: string
+                              type: array
+                            Federated:
+                              type: string
+                            Service:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  Version:
+                    description: Version specifies IAM policy version By default, this
+                      value is "2012-10-17"
+                    type: string
+                type: object
+              PolicyDocument:
+                description: PolicyDocument type defines IAM policy struct
+                properties:
+                  Statement:
+                    description: Statement allows list of statement object
+                    items:
+                      description: Statement type defines the AWS IAM policy statement
+                      properties:
+                        Action:
+                          description: Action allowed on specific resources
+                          items:
+                            type: string
+                          type: array
+                        Effect:
+                          description: Effect allowed/denied
+                          enum:
+                          - Allow
+                          - Deny
+                          type: string
+                        Resource:
+                          description: Resources defines target resources which IAM
+                            policy will be applied
+                          items:
+                            type: string
+                          type: array
+                        Sid:
+                          description: Sid is an optional field which describes the
+                            specific statement action
+                          type: string
+                      required:
+                      - Action
+                      - Effect
+                      - Resource
+                      type: object
+                    type: array
+                  Version:
+                    description: Version specifies IAM policy version By default, this
+                      value is "2012-10-17"
+                    type: string
+                required:
+                - Statement
+                type: object
+              RoleName:
+                description: RoleName can be passed only for privileged namespaces.
+                  This will be respected only during new iamrole creation and will be
+                  ignored during iamrole update Please check the documentation for more
+                  on how to configure privileged namespace using annotation for iam-manager
+                type: string
+            required:
+            - PolicyDocument
+            type: object
+          status:
+            description: IamroleStatus defines the observed state of Iamrole
+            properties:
+              errorDescription:
+                description: ErrorDescription in case of error
+                type: string
+              lastUpdatedTimestamp:
+                description: LastUpdatedTimestamp represents the last time the iam role
+                  has been modified
+                format: date-time
+                type: string
+              retryCount:
+                description: RetryCount in case of error
+                type: integer
+              roleARN:
+                description: RoleARN represents the ARN of an IAM role
+                type: string
+              roleID:
+                description: RoleID represents the unique ID of the role which can be
+                  used in S3 policy etc
+                type: string
+              roleName:
+                description: RoleName represents the name of the iam role created in
+                  AWS
+                type: string
+              state:
+                description: State of the resource
+                type: string
+            required:
+            - retryCount
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Kubernetes 1.22 deprecated the v1beta1 CRD API and replaced it with v1 CRD API. iam-manager's hack directory still uses the old API. Update that.

Note that this change is very specific about fixing the hack directory alone. There maybe more items that need the API upgrade. This change does not cover those.

Testing:
Before this change, using ./hack/install broke the iam-manager controller install. After this change, ./hack/install works fine.

Signed-off-by: Anusha Ragunathan <anusha.ragu@gmail.com>
