### PR TITLE
skip deletion if rolename is not present

### DIFF
--- a/internal/controllers/iamrole_controller.go
+++ b/internal/controllers/iamrole_controller.go
@@ -101,7 +101,10 @@ func (r *IamroleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			iamRole.Status.RetryCount = iamRole.Status.RetryCount + 1
 		}
 		log.Info("Iamrole delete request")
-		if iamRole.Status.State != iammanagerv1alpha1.PolicyNotAllowed {
+
+		// If PolicyNotAllowed, we should not have any role created.
+		// If RoleNameNotAvailable, the role should be deleted.
+		if iamRole.Status.State != iammanagerv1alpha1.PolicyNotAllowed && iamRole.Status.RoleName != "" {
 			//Get the roleName from status
 			roleName := iamRole.Status.RoleName
 			if err := r.IAMClient.DeleteRole(ctx, roleName); err != nil {


### PR DESCRIPTION
close #

**Could you share the solution in high level?**
- Sometime status role has been removed, but it kept on retrying deletion.
```
2024-03-29T17:44:30.526Z
INFO
Iamrole
delete request
2024-03-29T17:44:30.526Z
2024-03-29T17:44: 30.526Z
DEBUG
Initiating api call
{" roleName":
ERROR
Unable to list attached managed policies for role
｛roleName"：“"，“error"：“InvalidParameter: 1 val idation error（s） found.in- minimum field size of 1, ListAttachedRolePol iciesInput.RoleName.Mn"｝
sigs.k8s.io/controller-runtime/pkg/internal/controllen.(*Contnollen) reconcileHandler
/go/pkg/mod/sigs.k8s.io/controller-runtime@0.9.7/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)-processNextWorkItem
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:214
2024-03-29T17:44:30.526Z
ERROR
Unable to delete the role
{"ennon":
"Inval idParameter: 1 val idation error（s） found. Sn- minimum field size of 1, ListAttachedRolePol iciesInput.RoleName.Mn"｝
```
- Skip call aws deletion if rolename is not present as it has been deleted already.



**Could you share the test results?**
- [x] deployed to hdev, role deletion works good.
<img width="968" alt="Screenshot 2024-03-29 at 11 46 56 AM" src="https://github.com/keikoproj/iam-manager/assets/3823462/7f3b5569-7950-4da6-b245-fd5de0304f54">

