### PR TITLE
chore: upgrade to Go 1.24

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.24
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -32,4 +32,3 @@ jobs:
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
-          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Comprehensive documentation is available:
 
 | iam-manager Version | Kubernetes Version | Go Version | Key Features |
 |---------------------|-------------------|------------|--------------|
+| current | 1.16 - 1.27 | 1.24+ | Upgrade to Go 1.24 |
 | v0.22.0 | 1.16 - 1.25 | 1.19+ | IRSA regional endpoint configuration |
 | v0.21.0 | 1.16 - 1.24 | 1.18+ | Enhanced security features |
 | v0.20.0 | 1.16 - 1.23 | 1.17+ | Improved reconciliation controller |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keikoproj/iam-manager
 
-go 1.21
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6


### PR DESCRIPTION
# Upgrade to Go 1.24

## Overview
This PR upgrades the project from Go 1.21 to Go 1.24 to take advantage of the latest language improvements, performance optimizations, and security enhancements.

## Changes
- Updated `go.mod` to specify Go 1.24
- Updated GitHub Actions workflow (`unit_test.yaml`) to use Go 1.24
- Updated Dockerfile to use `golang:1.24` as the build image
- Added Go 1.24 compatibility information to the README version table

## Benefits
- Performance improvements from Go 1.24's optimized garbage collector and runtime
- Security enhancements from the latest patches and improvements
- Access to new standard library functionality
- Better compatibility with the modern Go ecosystem

## Testing
- All existing tests pass successfully with Go 1.24
- No regressions in functionality
- CI/CD pipelines complete successfully with Go 1.24

Fixes #262