### PR TITLE
Improve Makefile with Automatic Mock Generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: manager
 
 # Build manager binary
 manager: $(LOCALBIN)/manager
-$(LOCALBIN)/manager: generate fmt vet update
+$(LOCALBIN)/manager: generate fmt mock vet update
 	go build -o $(LOCALBIN)/manager cmd/main.go
 
 mock: $(MOCKGEN)
@@ -104,7 +104,7 @@ fmt:
 	go fmt ./...
 
 # Run go vet against code
-vet:
+vet: mock
 	go vet ./...
 
 # Generate code
@@ -137,6 +137,7 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+	rm -f $(KUSTOMIZE) || true
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: envtest


### PR DESCRIPTION
# Improve Makefile with Automatic Mock Generation

## Problem
When dependencies update (like the AWS SDK), new methods are added to interfaces which require mock updates. Currently, developers must manually run `go generate` to update mocks, which can lead to local build failures that don't occur in CI.

## Changes
- Added dependency on the `mock` target to the `vet` target to ensure mocks are automatically regenerated
- Updated the `manager` build chain to include mock generation
- Fixed the kustomize installation to handle existing binaries by removing them first

## Benefits
- Local development builds and CI builds are now consistent
- Eliminates confusing errors about missing interface methods in mocks
- Prevents build failures due to outdated mock files
- More robust kustomize installation process

## Testing
- Verified the changes by forcing a "missing method" scenario
- Confirmed the build process now automatically generates the needed mock files
- Successfully built the manager with `make`

## Note
This issue was discovered when updating to a newer AWS SDK version that added the new `AssociateAccessPolicy` method to the EKS interface, which wasn't present in the mocks.