### PR TITLE
feat: add IRSA annotation to Iamrole CR with specified ServiceAccount

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -77,7 +77,7 @@ iam.amazonaws.com/irsa-service-account: "service_account_name"
 OR
 You can provide the Service Account name in the config map and the controller will add the IRSA annotation to the IamRole CR:
 ```bash
-iam.irsa.serviceaccount: "service_account_name"
+iam.irsa.default.serviceaccount: "service_account_name"
 ```
 
 IAM Manager will create Service Account if its doesn't exist or update the service account with required annotations.

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,10 +70,16 @@ Note: To setup OIDC IDP in AWS IAM, you must provide required permissions to iam
 ```
 
 Request:  
-Once pre-requisites are completed, Attach following annotation to the IAM Role CR and IAM Manager will automatically attaches required trust policy to IAM Role.  
+Once pre-requisites are completed, attach following annotation to the IAM Role CR and IAM Manager will automatically attach required trust policy to IAM Role.  
 ```bash
 iam.amazonaws.com/irsa-service-account: "service_account_name"
 ```
+OR
+You can provide the Service Account name in the config map and the controller will add the IRSA annotation to the IamRole CR:
+```bash
+iam.irsa.serviceaccount: "service_account_name"
+```
+
 IAM Manager will create Service Account if its doesn't exist or update the service account with required annotations.
 
 Note: For kops clusters, you must install AWS [amazon-eks-pod-identity-webhook](https://github.com/aws/amazon-eks-pod-identity-webhook)  

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -61,7 +61,7 @@ const (
 	//propertyIRSAaRegionalEndpointDisabled can be used to disable sts regional endpoints for service accounts, and use global endpoint in us-east-1 instead
 	propertyIRSARegionalEndpointDisabled = "iam.irsa.regional.endpoint.disabled"
 
-	propertyIRSAServiceAccount = "iam.irsa.serviceaccount"
+	propertyIRSAServiceAccount = "iam.irsa.default.serviceaccount"
 )
 
 const (

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -60,6 +60,8 @@ const (
 
 	//propertyIRSAaRegionalEndpointDisabled can be used to disable sts regional endpoints for service accounts, and use global endpoint in us-east-1 instead
 	propertyIRSARegionalEndpointDisabled = "iam.irsa.regional.endpoint.disabled"
+
+	propertyIRSAServiceAccount = "iam.irsa.serviceAccount"
 )
 
 const (

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -61,7 +61,7 @@ const (
 	//propertyIRSAaRegionalEndpointDisabled can be used to disable sts regional endpoints for service accounts, and use global endpoint in us-east-1 instead
 	propertyIRSARegionalEndpointDisabled = "iam.irsa.regional.endpoint.disabled"
 
-	propertyIRSAServiceAccount = "iam.irsa.serviceAccount"
+	propertyIRSAServiceAccount = "iam.irsa.serviceaccount"
 )
 
 const (

--- a/internal/config/properties.go
+++ b/internal/config/properties.go
@@ -37,6 +37,7 @@ type Properties struct {
 	defaultTrustPolicy              string
 	iamRolePattern                  string
 	isIRSARegionalEndpointDisabled  string
+	irsaServiceAccount              string
 }
 
 func init() {
@@ -87,6 +88,7 @@ func LoadProperties(env string, cm ...*v1.ConfigMap) error {
 			defaultTrustPolicy:              os.Getenv("DEFAULT_TRUST_POLICY"),
 			iamRolePattern:                  os.Getenv("IAM_ROLE_PATTERN"),
 			isIRSARegionalEndpointDisabled:  os.Getenv("IRSA_REGIONAL_ENDPOINT_DISABLED"),
+			irsaServiceAccount:              os.Getenv("IRSA_SERVICE_ACCOUNT"),
 		}
 		return nil
 	}
@@ -101,12 +103,14 @@ func LoadProperties(env string, cm ...*v1.ConfigMap) error {
 	restrictedS3Resources := strings.Split(cm[0].Data[propertyIamPolicyS3Restricted], separator)
 	clusterName := cm[0].Data[propertyClusterName]
 	defaultTrustPolicy := cm[0].Data[propertyDefaultTrustPolicy]
+	irsaServiceAccount := cm[0].Data[propertyIRSAServiceAccount]
 	Props = &Properties{
 		allowedPolicyAction:       allowedPolicyAction,
 		restrictedPolicyResources: restrictedPolicyResources,
 		restrictedS3Resources:     restrictedS3Resources,
 		clusterName:               clusterName,
 		defaultTrustPolicy:        defaultTrustPolicy,
+		irsaServiceAccount:        irsaServiceAccount,
 	}
 
 	//Defaults
@@ -280,6 +284,10 @@ func (p *Properties) IsIRSARegionalEndpointDisabled() bool {
 		resp = true
 	}
 	return resp
+}
+
+func (p *Properties) IRSAServiceAccount() string {
+	return p.irsaServiceAccount
 }
 
 func (p *Properties) ClusterName() string {

--- a/internal/config/properties_test.go
+++ b/internal/config/properties_test.go
@@ -132,6 +132,7 @@ func (s *PropertiesSuite) TestLoadPropertiesSuccessWithCustom(c *check.C) {
 			"iam.role.max.limit.per.namespace":       "5",
 			"iam.role.pattern":                       "pfx-{{ .ObjectMeta.Name }}",
 			"iam.irsa.regional.endpoint.disabled":    "true",
+			"iam.irsa.serviceaccount":                "default",
 		},
 	}
 	err := LoadProperties("", cm)
@@ -140,6 +141,7 @@ func (s *PropertiesSuite) TestLoadPropertiesSuccessWithCustom(c *check.C) {
 	c.Assert(Props.ControllerDesiredFrequency(), check.Equals, 30)
 	c.Assert(Props.IamRolePattern(), check.Equals, "pfx-{{ .ObjectMeta.Name }}")
 	c.Assert(Props.IsIRSARegionalEndpointDisabled(), check.Equals, true)
+	c.Assert(Props.IRSAServiceAccount(), check.Equals, "default")
 }
 
 func (s *PropertiesSuite) TestGetAllowedPolicyAction(c *check.C) {

--- a/internal/config/properties_test.go
+++ b/internal/config/properties_test.go
@@ -132,7 +132,7 @@ func (s *PropertiesSuite) TestLoadPropertiesSuccessWithCustom(c *check.C) {
 			"iam.role.max.limit.per.namespace":       "5",
 			"iam.role.pattern":                       "pfx-{{ .ObjectMeta.Name }}",
 			"iam.irsa.regional.endpoint.disabled":    "true",
-			"iam.irsa.serviceaccount":                "default",
+			"iam.irsa.default.serviceaccount":        "default",
 		},
 	}
 	err := LoadProperties("", cm)


### PR DESCRIPTION
Controller will add the `iam.amazonaws.com/irsa-service-account: <service account name>` with the specified `iam.irsa.serviceaccount` data in the ConfigMap if it doesn't exist already.