### PR TITLE
feat: support secondary sandbox IAM role per namespace for agent sandbox use case

### DIFF
--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -238,7 +238,7 @@ func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
 	}
 
 	if isItUpdate {
-		if count > config.Props.MaxRolesAllowed() {
+		if count >= config.Props.MaxRolesAllowed() {
 			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
 		}
 	} else {

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -215,11 +215,11 @@ func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
 
 	if isItUpdate {
 		if count > config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
+			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 non-sandbox iamrole is allowed per namespace; use the iammanager.keikoproj.io/additional-role annotation for additional roles")
 		}
 	} else {
 		if count >= config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
+			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 non-sandbox iamrole is allowed per namespace; use the iammanager.keikoproj.io/additional-role annotation for additional roles")
 		}
 	}
 	//While doing update it should be fine to have

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -115,6 +116,9 @@ func (r *Iamrole) validateIAMPolicy(isItUpdate bool) error {
 	if err := r.validateNumberOfRoles(isItUpdate); err != nil {
 		allErrs = append(allErrs, err)
 	}
+	if err := r.validateRoleNameSuffixAnnotation(); err != nil {
+		allErrs = append(allErrs, err)
+	}
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -205,6 +209,26 @@ func (r *Iamrole) validateCustomResourceName() *field.Error {
 	return nil
 }
 
+// validateRoleNameSuffixAnnotation validates the iammanager.keikoproj.io/additional-role
+// annotation when present. CRs without this annotation are unaffected.
+func (r *Iamrole) validateRoleNameSuffixAnnotation() *field.Error {
+	suffix, ok := r.Annotations[config.IamManagerRoleNameSuffixAnnotation]
+	if !ok {
+		return nil
+	}
+	annotationPath := field.NewPath("metadata").Child("annotations").Key(config.IamManagerRoleNameSuffixAnnotation)
+	if suffix == "" {
+		return field.Invalid(annotationPath, suffix, "iammanager.keikoproj.io/additional-role must not be empty")
+	}
+	if len(suffix) > 3 {
+		return field.Invalid(annotationPath, suffix, "iammanager.keikoproj.io/additional-role value must be 3 characters or fewer")
+	}
+	if matched, _ := regexp.MatchString(`^[\w+=,.@-]+$`, suffix); !matched {
+		return field.Invalid(annotationPath, suffix, `iammanager.keikoproj.io/additional-role value must match AWS IAM role name character set [\w+=,.@-]`)
+	}
+	return nil
+}
+
 //Lets do a cheesy way to talk to API server
 
 func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
@@ -215,11 +239,11 @@ func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
 
 	if isItUpdate {
 		if count > config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 non-sandbox iamrole is allowed per namespace; use the iammanager.keikoproj.io/additional-role annotation for additional roles")
+			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
 		}
 	} else {
 		if count >= config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 non-sandbox iamrole is allowed per namespace; use the iammanager.keikoproj.io/additional-role annotation for additional roles")
+			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
 		}
 	}
 	//While doing update it should be fine to have

--- a/api/v1alpha1/iamrole_webhook.go
+++ b/api/v1alpha1/iamrole_webhook.go
@@ -232,21 +232,25 @@ func (r *Iamrole) validateRoleNameSuffixAnnotation() *field.Error {
 //Lets do a cheesy way to talk to API server
 
 func (r *Iamrole) validateNumberOfRoles(isItUpdate bool) *field.Error {
-	count, err := wClient.IamrolesCount(context.Background(), r.ObjectMeta.Namespace)
+	nonAdditional, additional, err := wClient.IamrolesCount(context.Background(), r.ObjectMeta.Namespace)
 	if err != nil {
 		panic(err)
 	}
 
-	if isItUpdate {
-		if count >= config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
-		}
-	} else {
-		if count >= config.Props.MaxRolesAllowed() {
-			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
-		}
-	}
-	//While doing update it should be fine to have
+	_, isAdditional := r.Annotations[config.IamManagerRoleNameSuffixAnnotation]
 
+	// On create the incoming CR is not yet in the list, so reject when the
+	// existing count already meets the limit. On update the CR is already
+	// counted, so the same existing role is allowed to pass through.
+	if isAdditional {
+		if (!isItUpdate && additional >= 1) || (isItUpdate && additional > 1) {
+			return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 additional (sandbox) role is allowed per namespace")
+		}
+		return nil
+	}
+
+	if (!isItUpdate && nonAdditional >= config.Props.MaxRolesAllowed()) || (isItUpdate && nonAdditional > config.Props.MaxRolesAllowed()) {
+		return field.Invalid(field.NewPath("metadata").Child("namespace"), r.ObjectMeta.Namespace, "only 1 role is allowed per namespace")
+	}
 	return nil
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -83,6 +83,12 @@ const (
 	IamManagerTagsAnnotation = "iammanager.keikoproj.io/tags"
 
 	IRSARegionalEndpointAnnotation = "eks.amazonaws.com/sts-regional-endpoints"
+	// IamManagerRoleNameSuffixAnnotation appends a suffix to the templated
+	// AWS IAM role name produced by `iam.role.pattern`. Lets a single
+	// namespace host multiple Iamrole CRs that produce distinct AWS role
+	// names without changing the cluster-wide naming template. Opt-in
+	// per CR; CRs without this annotation are unaffected.
+	IamManagerRoleNameSuffixAnnotation = "iammanager.keikoproj.io/additional-role"
 )
 
 const (

--- a/internal/controllers/iamrole_controller.go
+++ b/internal/controllers/iamrole_controller.go
@@ -243,19 +243,38 @@ func (r *IamroleReconciler) HandleReconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		nonAdditionalRoles := 0
+		additionalRoles := 0
 		for _, role := range iamRoles.Items {
-			if _, additionalRoles := role.Annotations[config.IamManagerRoleNameSuffixAnnotation]; !additionalRoles {
+			if _, isAdditional := role.Annotations[config.IamManagerRoleNameSuffixAnnotation]; isAdditional {
+				additionalRoles++
+			} else {
 				nonAdditionalRoles++
 			}
 		}
 
-		log.Info("Total Number of roles", "total", len(iamRoles.Items), "nonAdditionalRoles", nonAdditionalRoles, "allowed", config.Props.MaxRolesAllowed())
+		// Apply the limit that matches the CR currently being reconciled.
+		// The two limits are independent: over-quota on one side must not
+		// block a CR being reconciled on the other side.
+		_, isAdditional := iamRole.Annotations[config.IamManagerRoleNameSuffixAnnotation]
 
-		if config.Props.MaxRolesAllowed() < nonAdditionalRoles {
-			errMsg := "maximum number of allowed roles reached. You must delete any existing role before proceeding further"
-			log.Error(errors.New(errMsg), errMsg)
-			r.Recorder.Event(iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.RolesMaxLimitReached), errMsg)
-			return r.UpdateStatus(ctx, iamRole, iammanagerv1alpha1.IamroleStatus{RoleName: roleName, ErrorDescription: errMsg, State: iammanagerv1alpha1.RolesMaxLimitReached, LastUpdatedTimestamp: metav1.Now()}, requeueTime)
+		log.Info("Total Number of roles", "total", len(iamRoles.Items), "nonAdditionalRoles", nonAdditionalRoles, "additionalRoles", additionalRoles, "allowed", config.Props.MaxRolesAllowed(), "isAdditional", isAdditional)
+
+		if isAdditional {
+			// Cap additional (sandbox) roles at 1 per namespace. The CR being
+			// reconciled is already in the list, so > 1 means over-quota.
+			if additionalRoles > 1 {
+				errMsg := "maximum number of additional (sandbox) roles reached. Only 1 additional role is allowed per namespace"
+				log.Error(errors.New(errMsg), errMsg)
+				r.Recorder.Event(iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.RolesMaxLimitReached), errMsg)
+				return r.UpdateStatus(ctx, iamRole, iammanagerv1alpha1.IamroleStatus{RoleName: roleName, ErrorDescription: errMsg, State: iammanagerv1alpha1.RolesMaxLimitReached, LastUpdatedTimestamp: metav1.Now()}, requeueTime)
+			}
+		} else {
+			if config.Props.MaxRolesAllowed() < nonAdditionalRoles {
+				errMsg := "maximum number of allowed roles reached. You must delete any existing role before proceeding further"
+				log.Error(errors.New(errMsg), errMsg)
+				r.Recorder.Event(iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.RolesMaxLimitReached), errMsg)
+				return r.UpdateStatus(ctx, iamRole, iammanagerv1alpha1.IamroleStatus{RoleName: roleName, ErrorDescription: errMsg, State: iammanagerv1alpha1.RolesMaxLimitReached, LastUpdatedTimestamp: metav1.Now()}, requeueTime)
+			}
 		}
 		fallthrough
 	default:

--- a/internal/controllers/iamrole_controller.go
+++ b/internal/controllers/iamrole_controller.go
@@ -242,16 +242,16 @@ func (r *IamroleReconciler) HandleReconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, ignoreNotFound(err)
 		}
 
-		nonSandboxCount := 0
+		nonAdditionalRoles := 0
 		for _, role := range iamRoles.Items {
-			if _, isSandbox := role.Annotations[config.IamManagerRoleNameSuffixAnnotation]; !isSandbox {
-				nonSandboxCount++
+			if _, additionalRoles := role.Annotations[config.IamManagerRoleNameSuffixAnnotation]; !additionalRoles {
+				nonAdditionalRoles++
 			}
 		}
 
-		log.Info("Total Number of roles", "total", len(iamRoles.Items), "non_sandbox", nonSandboxCount, "allowed", config.Props.MaxRolesAllowed())
+		log.Info("Total Number of roles", "total", len(iamRoles.Items), "nonAdditionalRoles", nonAdditionalRoles, "allowed", config.Props.MaxRolesAllowed())
 
-		if config.Props.MaxRolesAllowed() < nonSandboxCount {
+		if config.Props.MaxRolesAllowed() < nonAdditionalRoles {
 			errMsg := "maximum number of allowed roles reached. You must delete any existing role before proceeding further"
 			log.Error(errors.New(errMsg), errMsg)
 			r.Recorder.Event(iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.RolesMaxLimitReached), errMsg)

--- a/internal/controllers/iamrole_controller.go
+++ b/internal/controllers/iamrole_controller.go
@@ -242,9 +242,16 @@ func (r *IamroleReconciler) HandleReconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, ignoreNotFound(err)
 		}
 
-		log.Info("Total Number of roles", "count", len(iamRoles.Items), "allowed", config.Props.MaxRolesAllowed())
+		nonSandboxCount := 0
+		for _, role := range iamRoles.Items {
+			if _, isSandbox := role.Annotations[config.IamManagerRoleNameSuffixAnnotation]; !isSandbox {
+				nonSandboxCount++
+			}
+		}
 
-		if config.Props.MaxRolesAllowed() < len(iamRoles.Items) {
+		log.Info("Total Number of roles", "total", len(iamRoles.Items), "non_sandbox", nonSandboxCount, "allowed", config.Props.MaxRolesAllowed())
+
+		if config.Props.MaxRolesAllowed() < nonSandboxCount {
 			errMsg := "maximum number of allowed roles reached. You must delete any existing role before proceeding further"
 			log.Error(errors.New(errMsg), errMsg)
 			r.Recorder.Event(iamRole, v1.EventTypeWarning, string(iammanagerv1alpha1.RolesMaxLimitReached), errMsg)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -186,7 +186,17 @@ func GenerateRoleName(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, 
 		return "", err
 	}
 
-	return buf.String(), nil
+	result := buf.String()
+
+	// Honor optional iammanager.keikoproj.io/additional-role annotation on the CR. Lets a single
+	// namespace host multiple Iamrole CRs that produce distinct AWS role
+	// names without changing the cluster-wide iam.role.pattern template.
+	if flag, suffix := parseAnnotations(ctx, config.IamManagerRoleNameSuffixAnnotation, iamRole.Annotations); flag {
+		result = result + suffix
+		log.Info("appended role-name suffix from annotation", "suffix", suffix, "finalName", result)
+	}
+
+	return result, nil
 }
 
 // parseAnnotations parses annotations attached to iam role resource and returns the value if found

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -24,6 +24,12 @@ import (
 	"github.com/keikoproj/iam-manager/pkg/logging"
 )
 
+// iamManagerRoleNameSuffixAnnotation mirrors the constant in internal/config
+// (config imports this package, so we can't import config here without a
+// cycle). Iamrole CRs carrying this annotation are sandbox/additional roles
+// and are excluded from the per-namespace limit enforced by IamrolesCount.
+const iamManagerRoleNameSuffixAnnotation = "iammanager.keikoproj.io/additional-role"
+
 type Client struct {
 	cl  kubernetes.Interface
 	dCl dynamic.Interface
@@ -100,7 +106,10 @@ type Iface interface {
 	CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string) error
 }
 
-// IamrolesCount function lists the "Iamrole" for a provided namespace
+// IamrolesCount lists Iamroles in the namespace and returns the count of
+// roles that do NOT carry the IamManagerRoleNameSuffixAnnotation. Annotated
+// (sandbox) Iamroles are excluded from the count so the per-namespace limit
+// only applies to standard roles.
 func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 	log := logging.Logger(ctx, "k8s", "client", "IamrolesCount")
 	log.WithValues("namespace", ns)
@@ -116,8 +125,19 @@ func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 		log.Error(err, "unable to list iamroles resources")
 		return 0, err
 	}
-	log.Info("Total number of roles", "count", len(roleList.Items))
-	return len(roleList.Items), nil
+
+	count := 0
+	skipped := 0
+	for _, item := range roleList.Items {
+		annotations := item.GetAnnotations()
+		if _, ok := annotations[iamManagerRoleNameSuffixAnnotation]; ok {
+			skipped++
+			continue
+		}
+		count++
+	}
+	log.Info("Iamrole count for limit enforcement", "non_sandbox_count", count, "sandbox_excluded", skipped, "total", len(roleList.Items))
+	return count, nil
 }
 
 func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -26,7 +26,7 @@ import (
 
 // iamManagerRoleNameSuffixAnnotation mirrors the constant in internal/config
 // (config imports this package, so we can't import config here without a
-// cycle). Iamrole CRs carrying this annotation are sandbox/additional roles
+// cycle). Iamrole CRs carrying this annotation are additional roles
 // and are excluded from the per-namespace limit enforced by IamrolesCount.
 const iamManagerRoleNameSuffixAnnotation = "iammanager.keikoproj.io/additional-role"
 
@@ -108,7 +108,7 @@ type Iface interface {
 
 // IamrolesCount lists Iamroles in the namespace and returns the count of
 // roles that do NOT carry the IamManagerRoleNameSuffixAnnotation. Annotated
-// (sandbox) Iamroles are excluded from the count so the per-namespace limit
+// (additional) Iamroles are excluded from the count so the per-namespace limit
 // only applies to standard roles.
 func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 	log := logging.Logger(ctx, "k8s", "client", "IamrolesCount")
@@ -136,7 +136,7 @@ func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 		}
 		count++
 	}
-	log.Info("Iamrole count for limit enforcement", "non_sandbox_count", count, "sandbox_excluded", skipped, "total", len(roleList.Items))
+	log.Info("Iamrole count for limit enforcement", "non_additional_count", count, "additional_excluded", skipped, "total", len(roleList.Items))
 	return count, nil
 }
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -27,7 +27,7 @@ import (
 // iamManagerRoleNameSuffixAnnotation mirrors the constant in internal/config
 // (config imports this package, so we can't import config here without a
 // cycle). Iamrole CRs carrying this annotation are additional roles
-// and are excluded from the per-namespace limit enforced by IamrolesCount.
+// and are counted separately by IamrolesCount.
 const iamManagerRoleNameSuffixAnnotation = "iammanager.keikoproj.io/additional-role"
 
 type Client struct {
@@ -99,18 +99,17 @@ func NewK8sManagerClient(client client.Client) *Client {
 
 // Iface defines required functions to be implemented by receivers
 type Iface interface {
-	IamrolesCount(ctx context.Context, ns string)
+	IamrolesCount(ctx context.Context, ns string) (int, int, error)
 	GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap
 	SetUpEventHandler(ctx context.Context) record.EventRecorder
 	GetNamespace(ctx context.Context, ns string) *v1.Namespace
 	CreateOrUpdateServiceAccount(ctx context.Context, saName string, ns string) error
 }
 
-// IamrolesCount lists Iamroles in the namespace and returns the count of
-// roles that do NOT carry the IamManagerRoleNameSuffixAnnotation. Annotated
-// (additional) Iamroles are excluded from the count so the per-namespace limit
-// only applies to standard roles.
-func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
+// IamrolesCount lists Iamroles in the namespace and returns the counts of
+// non-additional (standard) roles and additional roles separately,
+// so callers can enforce independent per-namespace limits on each.
+func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, int, error) {
 	log := logging.Logger(ctx, "k8s", "client", "IamrolesCount")
 	log.WithValues("namespace", ns)
 	log.V(1).Info("list api call")
@@ -123,21 +122,19 @@ func (c *Client) IamrolesCount(ctx context.Context, ns string) (int, error) {
 	roleList, err := c.dCl.Resource(iamCR).Namespace(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Error(err, "unable to list iamroles resources")
-		return 0, err
+		return 0, 0, err
 	}
 
-	count := 0
-	skipped := 0
+	nonAdditional, additional := 0, 0
 	for _, item := range roleList.Items {
-		annotations := item.GetAnnotations()
-		if _, ok := annotations[iamManagerRoleNameSuffixAnnotation]; ok {
-			skipped++
+		if _, ok := item.GetAnnotations()[iamManagerRoleNameSuffixAnnotation]; ok {
+			additional++
 			continue
 		}
-		count++
+		nonAdditional++
 	}
-	log.Info("Iamrole count for limit enforcement", "non_additional_count", count, "additional_excluded", skipped, "total", len(roleList.Items))
-	return count, nil
+	log.Info("Iamrole count for limit enforcement", "non_additional_count", nonAdditional, "additional_count", additional, "total", len(roleList.Items))
+	return nonAdditional, additional, nil
 }
 
 func (c *Client) GetConfigMap(ctx context.Context, ns string, name string) *v1.ConfigMap {


### PR DESCRIPTION


<!-- 
Please make sure you've read and understood our contributing guidelines.
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide the following information:
-->

## What type of PR is this?
<!-- Please check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ✅] Feature/Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Dependency upgrade

## Description
<!-- Please explain the changes you made here. -->
Allow a namespace to have a second (sandbox) IamRole in addition to the standard one, while keep the same 1-role-per-namespace counting limit logic against the default non-sandbox IAM role. Later this second role will be used for agent sandbox specifically.

## Related issue(s)
<!-- Please link the issue being fixed, e.g. Fixes #123 -->

## High-level overview of changes
<!-- 
Provide a high-level description of what changes were made and why.
This helps reviewers understand your approach.
-->

internal/config/constants.go

- Added the new constant IamManagerRoleNameSuffixAnnotation = **"iammanager.keikoproj.io/additional-role"** — the single source of truth for the annotation key.

internal/utils/utils.go (GenerateRoleName)

- After generating the role name from the template pattern, appends the annotation value as a suffix if present. This ensures the sandbox role gets a distinct AWS IAM role name (e.g., k8s-mynamespace-sandbox) instead of colliding with the primary role's name.

pkg/k8s/client.go (IamrolesCount)

- Previously returned len(roleList.Items) (all roles). Now loops through and skips any role carrying the additional-role annotation, returning only the non-sandbox count. Used by the webhook path.

internal/controllers/iamrole_controller.go (HandleReconcile)

- Previously used len(iamRoles.Items) for the max-roles guard. Now computes a nonSandboxCount by filtering out annotated roles before comparing against the limit. Used by the reconciler path.

api/v1alpha1/iamrole_webhook.go (validateNumberOfRoles)

- Updated the error message to be more descriptive, pointing users to the additional-role annotation instead of the generic "only 1 role is allowed" message.

## Testing performed
<!-- 
Describe the testing you've done:
- Unit tests added/modified
- Integration tests
- Manual testing performed 
- Any test outputs/results
-->
Manually triggered an namespace creation API with Sandbox as workloadType flag value. Verify if the default IAM role + sandbox specific IAM role are both created.

<img width="3298" height="818" alt="image" src="https://github.com/user-attachments/assets/890e8922-29f2-4df3-8fde-9270d03ef89d" />


## Checklist
<!-- Please check all that apply -->

- [✅] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [✅ ] I've added/updated tests that prove my fix is effective or that my feature works
- [✅] I've added necessary documentation (if appropriate)
- [✅] I've run `make test` locally and all tests pass
- [✅ ] I've signed-off my commits with `git commit -s` for DCO verification
- [✅ ] I've updated any relevant documentation
- [✅ ] Code follows the style guidelines of this project

## Additional information
<!--
Any other information that is important to this PR, such as screenshots 
of how the component looks before and after the change.
-->