### PR TITLE
fix: insert separator between role name and additional-role suffix

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -192,7 +192,7 @@ func GenerateRoleName(ctx context.Context, iamRole *iammanagerv1alpha1.Iamrole, 
 	// namespace host multiple Iamrole CRs that produce distinct AWS role
 	// names without changing the cluster-wide iam.role.pattern template.
 	if flag, suffix := parseAnnotations(ctx, config.IamManagerRoleNameSuffixAnnotation, iamRole.Annotations); flag {
-		result = result + suffix
+		result = result + "-" + suffix
 		log.Info("appended role-name suffix from annotation", "suffix", suffix, "finalName", result)
 	}
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -42,6 +42,7 @@ func (s *UtilsTestSuite) TearDownTest(c *check.C) {
 	s.mockCtrl.Finish()
 }
 
+
 func (s *UtilsTestSuite) TestDefaultTrustPolicyNoGoTemplate(c *check.C) {
 	tD := `{"Version": "2012-10-17", "Statement": [{"Effect": "Allow","Principal": {"AWS": ["arn:aws:iam::123456789012:role/trust_role"]},"Action": "sts:AssumeRole"}]}`
 	expect := v1alpha1.AssumeRolePolicyDocument{
@@ -654,6 +655,31 @@ func (s *UtilsTestSuite) TestGenerateNameFunctionWithNamespace(c *check.C) {
 	roleName, err := utils.GenerateRoleName(s.ctx, resource, *config.Props, nil)
 	c.Assert(roleName, check.Equals, "pfx+test-ns+foo")
 	c.Assert(err, check.IsNil)
+}
+
+func (s *UtilsTestSuite) TestGenerateNameFunctionWithAdditionalRoleAnnotation(c *check.C) {
+	cm := &v12.ConfigMap{
+		Data: map[string]string{
+			"aws.accountId":                  "123456789012", // Required mock for testing
+			"iam.role.derive.from.namespace": "false",
+			"iam.role.pattern":               "k8s-kubernetes-ikssandboxservice-usw2-{{ .ObjectMeta.Name }}",
+		},
+	}
+	config.Props = nil
+	err := config.LoadProperties("", cm)
+	c.Assert(err, check.IsNil)
+
+	resource := &v1alpha1.Iamrole{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "qal",
+			Annotations: map[string]string{
+				config.IamManagerRoleNameSuffixAnnotation: "sbx",
+			},
+		},
+	}
+	name, err := utils.GenerateRoleName(s.ctx, resource, *config.Props, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(name, check.Equals, "k8s-kubernetes-ikssandboxservice-usw2-qal-sbx")
 }
 
 func (s *UtilsTestSuite) TestGenerateNameFunctionWithPrivilegedNamespace(c *check.C) {


### PR DESCRIPTION
## Summary
  - The `iammanager.keikoproj.io/additional-role` annotation suffix was concatenated directly onto the templated IAM role name with no separator, so a role name like `k8s-kubernetes-ikssandboxservice-usw2-qal`
  with annotation value `sbx` produced `k8s-kubernetes-ikssandboxservice-usw2-qalsbx` instead of the intended `k8s-kubernetes-ikssandboxservice-usw2-qal-sbx`.
  - Fixed by inserting a `-` separator between the base role name and the suffix in `GenerateRoleName`.
  
  ## Test plan
  - [x] Added `TestGenerateNameFunctionWithAdditionalRoleAnnotation` in `internal/utils/utils_test.go`, verifying the fixed role name format.
  - [x] Ran `internal/utils` test suite locally — no regressions (pre-existing unrelated failures reproduced identically on unmodified master).
  - [x] `go build ./...` and `go vet ./...` pass. 

  Base: keikoproj/iam-manager:master, head: carlyjiang:fix/additional-role-suffix-separator (already pushed at commit 35aa325).